### PR TITLE
Edited firewall rule to be more restrictive

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -99,6 +99,7 @@ module "server" {
   forseti_email_sender                                = "${var.forseti_email_sender}"
   forseti_home                                        = "${var.forseti_home}"
   forseti_run_frequency                               = "${var.forseti_run_frequency}"
+  client_service_account_email                        = "${module.client.forseti-client-service-account}"
   server_type                                         = "${var.server_type}"
   server_region                                       = "${var.server_region}"
   server_boot_image                                   = "${var.server_boot_image}"

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -344,6 +344,7 @@ resource "google_compute_firewall" "forseti-server-allow-grpc" {
   network                 = "${var.network}"
   target_service_accounts = ["${google_service_account.forseti_server.email}"]
   source_ranges           = "${var.server_grpc_allow_ranges}"
+  source_service_accounts = ["${var.client_service_account_email}"]
   priority                = "100"
 
   allow {

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -560,6 +560,10 @@ variable "server_private" {
   default     = "false"
 }
 
+variable "client_service_account_email" {
+  description = "Service account of the forseti client"
+}
+
 #------------#
 # Forseti db #
 #------------#
@@ -627,7 +631,7 @@ variable "network_project" {
 variable "server_grpc_allow_ranges" {
   description = "List of CIDRs that will be allowed gRPC access to forseti server"
   type        = "list"
-  default     = ["10.128.0.0/9"]
+  default     = []
 }
 
 variable "server_ssh_allow_ranges" {


### PR DESCRIPTION
Firewall rule now contains flag to allow service accounts to be the source instead of source IP range for GRPC rule