### PR TITLE
Fix issue #110

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -94,10 +94,11 @@ suites:
           controls:
             - forseti-command-server
             - server
-          hosts_output: forseti-server-vm-public-ip
+          hosts_output: forseti-server-vm-ip
           user: ubuntu
           key_files:
             - test/fixtures/shared_vpc/sshkey
+          proxy_command: ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -o LogLevel=ERROR -o ForwardAgent=no -i test/fixtures/bastion/tls_private_key ubuntu@<%= `terraform output -state test/fixtures/shared_vpc/terraform.tfstate.d/kitchen-terraform-shared-vpc-local/terraform.tfstate bastion_host`.strip %> -p 22 -W %h:%p
           shell: true
           shell_options: "--login"
         - name: forseti-client
@@ -105,10 +106,11 @@ suites:
           controls:
             - forseti-command-client
             - client
-          hosts_output: forseti-client-vm-public-ip
+          hosts_output: forseti-client-vm-ip
           user: ubuntu
           key_files:
             - test/fixtures/shared_vpc/sshkey
+          proxy_command: ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -o LogLevel=ERROR -o ForwardAgent=no -i test/fixtures/bastion/tls_private_key ubuntu@<%= `terraform output -state test/fixtures/shared_vpc/terraform.tfstate.d/kitchen-terraform-shared-vpc-local/terraform.tfstate bastion_host`.strip %> -p 22 -W %h:%p
           shell: true
           shell_options: "--login"
     provisioner:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Extending the adopted spec, each change should have a link to its corresponding 
 
 ### Added
 
- - Check for both empty values org_id and folder_id [#152]
+- Add 50052 port in Firewall rule for Config Validator. [#155]
+- Check for both empty values org_id and folder_id [#152]
 
 ## [v1.6.0] - 2019-05-14
 
@@ -160,6 +161,7 @@ Extending the adopted spec, each change should have a link to its corresponding 
 [v1.5.1]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v1.5.0...v1.5.1
 [v1.6.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v1.5.1...v1.6.0
 
+[#155]: https://github.com/forseti-security/terraform-google-forseti/pull/155
 [#146]: https://github.com/terraform-google-modules/terraform-google-forseti/pull/146
 [#145]: https://github.com/terraform-google-modules/terraform-google-forseti/pull/145
 [#137]: https://github.com/terraform-google-modules/terraform-google-forseti/pull/137

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Extending the adopted spec, each change should have a link to its corresponding 
 
 ## [Unreleased]
 
+## [v2.0.0] - 2019-05-16
+
+### Changed
+
+- Removed public IP address outputs. [#163]
+
 ### Added
 
 - Enable CSCC API when violations are enabled. [#158]
@@ -152,7 +158,7 @@ Extending the adopted spec, each change should have a link to its corresponding 
 ### ADDED
 - This is the initial release of the Forseti module.
 
-[Unreleased]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v1.6.0...HEAD
+[Unreleased]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v2.0.0...HEAD
 [v0.1.0]: https://github.com/terraform-google-modules/terraform-google-forseti/releases/tag/v0.1.0
 [v1.0.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v0.1.0...v1.0.0
 [v1.1.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v1.0.0...v1.1.0
@@ -165,7 +171,9 @@ Extending the adopted spec, each change should have a link to its corresponding 
 [v1.5.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v1.4.2...v1.5.0
 [v1.5.1]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v1.5.0...v1.5.1
 [v1.6.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v1.5.1...v1.6.0
+[v2.0.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v1.6.0...v2.0.0
 
+[#163]: https://github.com/forseti-security/terraform-google-forseti/pull/163
 [#157]: https://github.com/forseti-security/terraform-google-forseti/pull/157
 [#158]: https://github.com/forseti-security/terraform-google-forseti/pull/158
 [#155]: https://github.com/forseti-security/terraform-google-forseti/pull/155

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Extending the adopted spec, each change should have a link to its corresponding 
 ### Added
 
 - Add 50052 port in Firewall rule for Config Validator. [#155]
-- Check for both empty values org_id and folder_id [#152]
+- Check for both empty values org_id and folder_id. [#152]
 
 ## [v1.6.0] - 2019-05-14
 
@@ -162,6 +162,7 @@ Extending the adopted spec, each change should have a link to its corresponding 
 [v1.6.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v1.5.1...v1.6.0
 
 [#155]: https://github.com/forseti-security/terraform-google-forseti/pull/155
+[#152]: https://github.com/forseti-security/terraform-google-forseti/pull/152
 [#146]: https://github.com/terraform-google-modules/terraform-google-forseti/pull/146
 [#145]: https://github.com/terraform-google-modules/terraform-google-forseti/pull/145
 [#137]: https://github.com/terraform-google-modules/terraform-google-forseti/pull/137

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,13 @@ Extending the adopted spec, each change should have a link to its corresponding 
 
 ### Added
 
+- Enable CSCC API when violations are enabled. [#158]
 - Add 50052 port in Firewall rule for Config Validator. [#155]
 - Check for both empty values org_id and folder_id. [#152]
+
+### Changed
+
+- Updated server firewall rule to restrict by service accounts. [#157]
 
 ## [v1.6.0] - 2019-05-14
 
@@ -161,6 +166,8 @@ Extending the adopted spec, each change should have a link to its corresponding 
 [v1.5.1]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v1.5.0...v1.5.1
 [v1.6.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v1.5.1...v1.6.0
 
+[#157]: https://github.com/forseti-security/terraform-google-forseti/pull/157
+[#158]: https://github.com/forseti-security/terraform-google-forseti/pull/158
 [#155]: https://github.com/forseti-security/terraform-google-forseti/pull/155
 [#152]: https://github.com/forseti-security/terraform-google-forseti/pull/152
 [#146]: https://github.com/terraform-google-modules/terraform-google-forseti/pull/146

--- a/README.md
+++ b/README.md
@@ -182,12 +182,10 @@ Then perform the following commands on the config folder:
 | forseti-client-storage-bucket | Forseti Client storage bucket |
 | forseti-client-vm-ip | Forseti Client VM private IP address |
 | forseti-client-vm-name | Forseti Client VM name |
-| forseti-client-vm-public-ip | Forseti Server VM public IP address |
 | forseti-server-service-account | Forseti Server service account |
 | forseti-server-storage-bucket | Forseti Server storage bucket |
 | forseti-server-vm-ip | Forseti Server VM private IP address |
 | forseti-server-vm-name | Forseti Server VM name |
-| forseti-server-vm-public-ip | Forseti Server VM public IP address |
 | suffix | The random suffix appended to Forseti resources |
 
 [^]: (autogen_docs_end)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A simple setup is provided in the examples folder; however, the usage of the mod
 
     module "forseti" {
       source  = "terraform-google-modules/forseti/google"
-      version = "~> 1.2"
+      version = "~> 2.0.0"
 
       gsuite_admin_email = "superadmin@yourdomain.com"
       domain             = "yourdomain.com"

--- a/examples/external_ip/README.md
+++ b/examples/external_ip/README.md
@@ -22,7 +22,6 @@ This example illustrates how to set up a minimal Forseti installation.
 
 | Name | Description |
 |------|-------------|
-| forseti-client-public-ip | Forseti Client VM public IP address |
 | forseti-client-service-account | Forseti Client service account |
 | forseti-client-storage-bucket | Forseti Client storage bucket |
 | forseti-client-vm-ip | Forseti Client VM private IP address |

--- a/examples/external_ip/outputs.tf
+++ b/examples/external_ip/outputs.tf
@@ -24,11 +24,6 @@ output "forseti-client-vm-ip" {
   value       = "${module.forseti-install-simple.forseti-client-vm-ip}"
 }
 
-output "forseti-client-public-ip" {
-  description = "Forseti Client VM public IP address"
-  value       = "${google_compute_address.forseti_client_ip.address}"
-}
-
 output "forseti-client-service-account" {
   description = "Forseti Client service account"
   value       = "${module.forseti-install-simple.forseti-client-service-account}"

--- a/examples/shared_vpc/README.md
+++ b/examples/shared_vpc/README.md
@@ -28,12 +28,10 @@ This example illustrates how to set up a Forseti installation with shared VPC.
 | forseti-client-storage-bucket | Forseti Client storage bucket |
 | forseti-client-vm-ip | Forseti Client VM private IP address |
 | forseti-client-vm-name | Forseti Client VM name |
-| forseti-client-vm-public-ip | Forseti Client VM public IP address |
 | forseti-server-service-account | Forseti Server service account |
 | forseti-server-storage-bucket | Forseti Server storage bucket |
 | forseti-server-vm-ip | Forseti Server VM private IP address |
 | forseti-server-vm-name | Forseti Server VM name |
-| forseti-server-vm-public-ip | Forseti Server VM public IP address |
 | network | Network where server and client will be deployed |
 | network\_project | ID of the network project holding shared VPC |
 | project\_id | ID of the service project |

--- a/examples/shared_vpc/outputs.tf
+++ b/examples/shared_vpc/outputs.tf
@@ -34,11 +34,6 @@ output "forseti-server-vm-ip" {
   value       = "${module.forseti.forseti-server-vm-ip}"
 }
 
-output "forseti-server-vm-public-ip" {
-  description = "Forseti Server VM public IP address"
-  value       = "${module.forseti.forseti-server-vm-public-ip}"
-}
-
 output "forseti-server-vm-name" {
   description = "Forseti Server VM name"
   value       = "${module.forseti.forseti-server-vm-name}"
@@ -47,11 +42,6 @@ output "forseti-server-vm-name" {
 output "forseti-client-vm-ip" {
   description = "Forseti Client VM private IP address"
   value       = "${module.forseti.forseti-client-vm-ip}"
-}
-
-output "forseti-client-vm-public-ip" {
-  description = "Forseti Client VM public IP address"
-  value       = "${module.forseti.forseti-client-vm-public-ip}"
 }
 
 output "forseti-client-vm-name" {

--- a/main.tf
+++ b/main.tf
@@ -232,6 +232,8 @@ module "server" {
   bigquery_acl_violations_should_notify               = "${var.bigquery_acl_violations_should_notify}"
   audit_logging_violations_should_notify              = "${var.audit_logging_violations_should_notify}"
 
+  violations_slack_webhook                            = "${var.violations_slack_webhook}"
+
   groups_settings_max_calls                = "${var.groups_settings_max_calls}"
   groups_settings_period                   = "${var.groups_settings_period}"
   groups_settings_disable_polling          = "${var.groups_settings_disable_polling}"

--- a/main.tf
+++ b/main.tf
@@ -112,6 +112,7 @@ module "server" {
   forseti_email_sender                                = "${var.forseti_email_sender}"
   forseti_home                                        = "${var.forseti_home}"
   forseti_run_frequency                               = "${var.forseti_run_frequency}"
+  client_service_account_email                        = "${module.client.forseti-client-service-account}"
   server_type                                         = "${var.server_type}"
   server_region                                       = "${var.server_region}"
   server_boot_image                                   = "${var.server_boot_image}"

--- a/modules/client/outputs.tf
+++ b/modules/client/outputs.tf
@@ -24,11 +24,6 @@ output "forseti-client-vm-ip" {
   value       = "${google_compute_instance.forseti-client.network_interface.0.network_ip}"
 }
 
-output "forseti-client-vm-public-ip" {
-  description = "Forseti Client VM public IP address"
-  value       = "${google_compute_instance.forseti-client.network_interface.0.access_config.0.nat_ip}"
-}
-
 output "forseti-client-service-account" {
   description = "Forseti Client service account"
   value       = "${google_service_account.forseti_client.email}"

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -237,6 +237,8 @@ data "template_file" "forseti_server_config" {
     BIGQUERY_ACL_VIOLATIONS_SHOULD_NOTIFY               = "${var.bigquery_acl_violations_should_notify ? "true" : "false"}"
     AUDIT_LOGGING_VIOLATIONS_SHOULD_NOTIFY              = "${var.audit_logging_violations_should_notify ? "true" : "false"}"
 
+    VIOLATIONS_SLACK_WEBHOOK                            = "${var.violations_slack_webhook}"
+
     GROUPS_SETTINGS_MAX_CALLS                = "${var.groups_settings_max_calls}"
     GROUPS_SETTINGS_PERIOD                   = "${var.groups_settings_period}"
     GROUPS_SETTINGS_DISABLE_POLLING          = "${var.groups_settings_disable_polling ? "true" : "false"}"

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -463,7 +463,7 @@ resource "google_sql_database_instance" "master" {
 }
 
 resource "google_sql_database" "forseti-db" {
-  name     = "forseti_security"
+  name     = "${var.cloudsql_db_name}"
   project  = "${var.project_id}"
   instance = "${google_sql_database_instance.master.name}"
 }

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -344,6 +344,7 @@ resource "google_compute_firewall" "forseti-server-allow-grpc" {
   network                 = "${var.network}"
   target_service_accounts = ["${google_service_account.forseti_server.email}"]
   source_ranges           = "${var.server_grpc_allow_ranges}"
+  source_service_accounts = ["${var.client_service_account_email}"]
   priority                = "100"
 
   allow {

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -348,7 +348,7 @@ resource "google_compute_firewall" "forseti-server-allow-grpc" {
 
   allow {
     protocol = "tcp"
-    ports    = ["50051"]
+    ports    = ["50051", "50052"]
   }
 
   depends_on = ["null_resource.services-dependency"]

--- a/modules/server/outputs.tf
+++ b/modules/server/outputs.tf
@@ -24,11 +24,6 @@ output "forseti-server-vm-ip" {
   value       = "${google_compute_instance.forseti-server.network_interface.0.network_ip}"
 }
 
-output "forseti-server-vm-public-ip" {
-  description = "Forseti Server VM public IP address"
-  value       = "${google_compute_instance.forseti-server.network_interface.0.access_config.0.nat_ip}"
-}
-
 output "forseti-server-service-account" {
   description = "Forseti Server service account"
   value       = "${google_service_account.forseti_server.email}"

--- a/modules/server/templates/configs/forseti_conf_server.yaml.tpl
+++ b/modules/server/templates/configs/forseti_conf_server.yaml.tpl
@@ -288,7 +288,7 @@ notifier:
             - name: slack_webhook
               configuration:
                 data_format: json  # slack only supports json
-                webhook_url: ${IAM_POLICY_VIOLATIONS_SLACK_WEBHOOK}
+                webhook_url: %{ if IAM_POLICY_VIOLATIONS_SLACK_WEBHOOK != "" }${IAM_POLICY_VIOLATIONS_SLACK_WEBHOOK}{ else }${VIOLATIONS_SLACK_WEBHOOK}%{ endif }
 
         - resource: audit_logging_violations
           should_notify: ${AUDIT_LOGGING_VIOLATIONS_SHOULD_NOTIFY}
@@ -301,6 +301,10 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
 
         - resource: blacklist_violations
           should_notify: ${BLACKLIST_VIOLATIONS_SHOULD_NOTIFY}
@@ -313,6 +317,10 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
 
         - resource: bigquery_acl_violations
           should_notify: ${BIGQUERY_ACL_VIOLATIONS_SHOULD_NOTIFY}
@@ -325,6 +333,10 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
 
         - resource: buckets_acl_violations
           should_notify: ${BUCKETS_ACL_VIOLATIONS_SHOULD_NOTIFY}
@@ -337,6 +349,10 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
 
         - resource: config_validator_violations
           should_notify: ${CONFIG_VALIDATOR_VIOLATIONS_SHOULD_NOTIFY}
@@ -349,6 +365,10 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
 
         - resource: cloudsql_acl_violations
           should_notify: ${CLOUDSQL_ACL_VIOLATIONS_SHOULD_NOTIFY}
@@ -361,6 +381,10 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
 
         - resource: enabled_apis_violations
           should_notify: ${ENABLED_APIS_VIOLATIONS_SHOULD_NOTIFY}
@@ -373,6 +397,10 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
 
         - resource: firewall_rule_violations
           should_notify: ${FIREWALL_RULE_VIOLATIONS_SHOULD_NOTIFY}
@@ -385,6 +413,10 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
 
         - resource: forwarding_rule_violations
           should_notify: ${FORWARDING_RULE_VIOLATIONS_SHOULD_NOTIFY}
@@ -397,6 +429,10 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
 
         - resource: groups_settings_violations
           should_notify: ${GROUPS_SETTINGS_VIOLATIONS_SHOULD_NOTIFY}
@@ -409,6 +445,10 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://{FORSETI_BUCKET}/scanner_violations
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
 
         - resource: ke_version_violations
           should_notify: ${KE_VERSION_VIOLATIONS_SHOULD_NOTIFY}
@@ -421,6 +461,10 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
 
         - resource: ke_violations
           should_notify: ${KE_VIOLATIONS_SHOULD_NOTIFY}
@@ -433,6 +477,10 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
 
         - resource: kms_violations
           should_notify: ${KMS_VIOLATIONS_SHOULD_NOTIFY}
@@ -452,7 +500,7 @@ notifier:
             - name: slack_webhook
               configuration:
                 data_format: json  # slack only supports json
-                webhook_url: ${KMS_VIOLATIONS_SLACK_WEBHOOK}
+                webhook_url: %{ if KMS_VIOLATIONS_SLACK_WEBHOOK != "" }${KMS_VIOLATIONS_SLACK_WEBHOOK}{ else }${VIOLATIONS_SLACK_WEBHOOK}%{ endif }
 
         - resource: groups_violations
           should_notify: ${GROUPS_VIOLATIONS_SHOULD_NOTIFY}
@@ -465,6 +513,10 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
 
         - resource: instance_network_interface_violations
           should_notify: ${INSTANCE_NETWORK_INTERFACE_VIOLATIONS_SHOULD_NOTIFY}
@@ -477,6 +529,10 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
 
         - resource: iap_violations
           should_notify: ${IAP_VIOLATIONS_SHOULD_NOTIFY}
@@ -489,6 +545,10 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
 
         - resource: lien_violations
           should_notify: ${LIEN_VIOLATIONS_SHOULD_NOTIFY}
@@ -501,6 +561,10 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
 
         - resource: location_violations
           should_notify: ${LOCATION_VIOLATIONS_SHOULD_NOTIFY}
@@ -513,6 +577,10 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
 
         - resource: log_sink_violations
           should_notify: ${LOG_SINK_VIOLATIONS_SHOULD_NOTIFY}
@@ -525,6 +593,10 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
 
         - resource: resource_violations
           should_notify: ${RESOURCE_VIOLATIONS_SHOULD_NOTIFY}
@@ -537,6 +609,10 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
 
         - resource: service_account_key_violations
           should_notify: ${SERVICE_ACCOUNT_KEY_VIOLATIONS_SHOULD_NOTIFY}
@@ -549,6 +625,10 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
 
         - resource: external_project_access_violations
           should_notify: ${EXTERNAL_PROJECT_ACCESS_VIOLATIONS_SHOULD_NOTIFY}
@@ -561,6 +641,10 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
 
     violation:
       cscc:

--- a/modules/server/templates/configs/forseti_conf_server.yaml.tpl
+++ b/modules/server/templates/configs/forseti_conf_server.yaml.tpl
@@ -285,10 +285,12 @@ notifier:
             # Create an incoming webhook in your organization's Slack setting, located at:
             # https://[your_org].slack.com/apps/manage/custom-integrations
             # Add the provided URL in the configuration below in `webhook_url`.
+            %{ if IAM_POLICY_VIOLATIONS_SLACK_WEBHOOK != "" || VIOLATIONS_SLACK_WEBHOOK != "" }
             - name: slack_webhook
               configuration:
                 data_format: json  # slack only supports json
                 webhook_url: %{ if IAM_POLICY_VIOLATIONS_SLACK_WEBHOOK != "" }${IAM_POLICY_VIOLATIONS_SLACK_WEBHOOK}{ else }${VIOLATIONS_SLACK_WEBHOOK}%{ endif }
+            %{ endif }
 
         - resource: audit_logging_violations
           should_notify: ${AUDIT_LOGGING_VIOLATIONS_SHOULD_NOTIFY}
@@ -301,10 +303,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
             - name: slack_webhook
               configuration:
                 data_format: json  # slack only supports json
                 webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: blacklist_violations
           should_notify: ${BLACKLIST_VIOLATIONS_SHOULD_NOTIFY}
@@ -317,10 +321,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
             - name: slack_webhook
               configuration:
                 data_format: json  # slack only supports json
                 webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: bigquery_acl_violations
           should_notify: ${BIGQUERY_ACL_VIOLATIONS_SHOULD_NOTIFY}
@@ -333,10 +339,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
             - name: slack_webhook
               configuration:
                 data_format: json  # slack only supports json
                 webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: buckets_acl_violations
           should_notify: ${BUCKETS_ACL_VIOLATIONS_SHOULD_NOTIFY}
@@ -349,10 +357,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
             - name: slack_webhook
               configuration:
                 data_format: json  # slack only supports json
                 webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: config_validator_violations
           should_notify: ${CONFIG_VALIDATOR_VIOLATIONS_SHOULD_NOTIFY}
@@ -365,10 +375,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
             - name: slack_webhook
               configuration:
                 data_format: json  # slack only supports json
                 webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: cloudsql_acl_violations
           should_notify: ${CLOUDSQL_ACL_VIOLATIONS_SHOULD_NOTIFY}
@@ -381,10 +393,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
             - name: slack_webhook
               configuration:
                 data_format: json  # slack only supports json
                 webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: enabled_apis_violations
           should_notify: ${ENABLED_APIS_VIOLATIONS_SHOULD_NOTIFY}
@@ -397,10 +411,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
             - name: slack_webhook
               configuration:
                 data_format: json  # slack only supports json
                 webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: firewall_rule_violations
           should_notify: ${FIREWALL_RULE_VIOLATIONS_SHOULD_NOTIFY}
@@ -413,10 +429,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
             - name: slack_webhook
               configuration:
                 data_format: json  # slack only supports json
                 webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: forwarding_rule_violations
           should_notify: ${FORWARDING_RULE_VIOLATIONS_SHOULD_NOTIFY}
@@ -429,10 +447,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
             - name: slack_webhook
               configuration:
                 data_format: json  # slack only supports json
                 webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: groups_settings_violations
           should_notify: ${GROUPS_SETTINGS_VIOLATIONS_SHOULD_NOTIFY}
@@ -445,10 +465,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://{FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
             - name: slack_webhook
               configuration:
                 data_format: json  # slack only supports json
                 webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: ke_version_violations
           should_notify: ${KE_VERSION_VIOLATIONS_SHOULD_NOTIFY}
@@ -461,10 +483,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
             - name: slack_webhook
               configuration:
                 data_format: json  # slack only supports json
                 webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: ke_violations
           should_notify: ${KE_VIOLATIONS_SHOULD_NOTIFY}
@@ -477,10 +501,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
             - name: slack_webhook
               configuration:
                 data_format: json  # slack only supports json
                 webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: kms_violations
           should_notify: ${KMS_VIOLATIONS_SHOULD_NOTIFY}
@@ -497,10 +523,12 @@ notifier:
             # Create an incoming webhook in your organization's Slack setting, located at:
             # https://[your_org].slack.com/apps/manage/custom-integrations
             # Add the provided URL in the configuration below in `webhook_url`.
+            %{ if KMS_VIOLATIONS_SLACK_WEBHOOK != "" || VIOLATIONS_SLACK_WEBHOOK != "" }
             - name: slack_webhook
               configuration:
                 data_format: json  # slack only supports json
                 webhook_url: %{ if KMS_VIOLATIONS_SLACK_WEBHOOK != "" }${KMS_VIOLATIONS_SLACK_WEBHOOK}{ else }${VIOLATIONS_SLACK_WEBHOOK}%{ endif }
+            %{ endif }
 
         - resource: groups_violations
           should_notify: ${GROUPS_VIOLATIONS_SHOULD_NOTIFY}
@@ -513,10 +541,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
             - name: slack_webhook
               configuration:
                 data_format: json  # slack only supports json
                 webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: instance_network_interface_violations
           should_notify: ${INSTANCE_NETWORK_INTERFACE_VIOLATIONS_SHOULD_NOTIFY}
@@ -529,10 +559,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
             - name: slack_webhook
               configuration:
                 data_format: json  # slack only supports json
                 webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: iap_violations
           should_notify: ${IAP_VIOLATIONS_SHOULD_NOTIFY}
@@ -545,10 +577,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
             - name: slack_webhook
               configuration:
                 data_format: json  # slack only supports json
                 webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: lien_violations
           should_notify: ${LIEN_VIOLATIONS_SHOULD_NOTIFY}
@@ -561,10 +595,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
             - name: slack_webhook
               configuration:
                 data_format: json  # slack only supports json
                 webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: location_violations
           should_notify: ${LOCATION_VIOLATIONS_SHOULD_NOTIFY}
@@ -577,10 +613,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
             - name: slack_webhook
               configuration:
                 data_format: json  # slack only supports json
                 webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: log_sink_violations
           should_notify: ${LOG_SINK_VIOLATIONS_SHOULD_NOTIFY}
@@ -593,10 +631,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
             - name: slack_webhook
               configuration:
                 data_format: json  # slack only supports json
                 webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: resource_violations
           should_notify: ${RESOURCE_VIOLATIONS_SHOULD_NOTIFY}
@@ -609,10 +649,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
             - name: slack_webhook
               configuration:
                 data_format: json  # slack only supports json
                 webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: service_account_key_violations
           should_notify: ${SERVICE_ACCOUNT_KEY_VIOLATIONS_SHOULD_NOTIFY}
@@ -625,10 +667,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
             - name: slack_webhook
               configuration:
                 data_format: json  # slack only supports json
                 webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: external_project_access_violations
           should_notify: ${EXTERNAL_PROJECT_ACCESS_VIOLATIONS_SHOULD_NOTIFY}
@@ -641,10 +685,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
             - name: slack_webhook
               configuration:
                 data_format: json  # slack only supports json
                 webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
     violation:
       cscc:

--- a/modules/server/templates/configs/forseti_conf_server.yaml.tpl
+++ b/modules/server/templates/configs/forseti_conf_server.yaml.tpl
@@ -289,7 +289,7 @@ notifier:
             - name: slack_webhook
               configuration:
                 data_format: json  # slack only supports json
-                webhook_url: %{ if IAM_POLICY_VIOLATIONS_SLACK_WEBHOOK != "" }${IAM_POLICY_VIOLATIONS_SLACK_WEBHOOK}{ else }${VIOLATIONS_SLACK_WEBHOOK}%{ endif }
+                webhook_url: %{ if IAM_POLICY_VIOLATIONS_SLACK_WEBHOOK != "" }${IAM_POLICY_VIOLATIONS_SLACK_WEBHOOK}%{ else }${VIOLATIONS_SLACK_WEBHOOK}%{ endif }
             %{ endif }
 
         - resource: audit_logging_violations
@@ -527,7 +527,7 @@ notifier:
             - name: slack_webhook
               configuration:
                 data_format: json  # slack only supports json
-                webhook_url: %{ if KMS_VIOLATIONS_SLACK_WEBHOOK != "" }${KMS_VIOLATIONS_SLACK_WEBHOOK}{ else }${VIOLATIONS_SLACK_WEBHOOK}%{ endif }
+                webhook_url: %{ if KMS_VIOLATIONS_SLACK_WEBHOOK != "" }${KMS_VIOLATIONS_SLACK_WEBHOOK}%{ else }${VIOLATIONS_SLACK_WEBHOOK}%{ endif }
             %{ endif }
 
         - resource: groups_violations

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -560,6 +560,10 @@ variable "server_private" {
   default     = "false"
 }
 
+variable "client_service_account_email" {
+  description = "Service account of the forseti client"
+}
+
 #------------#
 # Forseti db #
 #------------#
@@ -627,7 +631,7 @@ variable "network_project" {
 variable "server_grpc_allow_ranges" {
   description = "List of CIDRs that will be allowed gRPC access to forseti server"
   type        = "list"
-  default     = ["10.128.0.0/9"]
+  default     = []
 }
 
 variable "server_ssh_allow_ranges" {

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -379,6 +379,11 @@ variable "service_account_key_enabled" {
 #-------------------------#
 # Forseti config notifier #
 #-------------------------#
+variable "violations_slack_webhook" {
+  description = "Slack webhook for any violation. Will apply to all scanner violation notifiers."
+  default     = ""
+}
+
 variable "iam_policy_violations_should_notify" {
   description = "Notify for IAM Policy violations"
   default     = "true"

--- a/outputs.tf
+++ b/outputs.tf
@@ -24,11 +24,6 @@ output "forseti-server-vm-ip" {
   value       = "${module.server.forseti-server-vm-ip}"
 }
 
-output "forseti-server-vm-public-ip" {
-  description = "Forseti Server VM public IP address"
-  value       = "${module.server.forseti-server-vm-public-ip}"
-}
-
 output "forseti-client-vm-name" {
   description = "Forseti Client VM name"
   value       = "${module.client.forseti-client-vm-name}"
@@ -37,11 +32,6 @@ output "forseti-client-vm-name" {
 output "forseti-client-vm-ip" {
   description = "Forseti Client VM private IP address"
   value       = "${module.client.forseti-client-vm-ip}"
-}
-
-output "forseti-client-vm-public-ip" {
-  description = "Forseti Server VM public IP address"
-  value       = "${module.client.forseti-client-vm-public-ip}"
 }
 
 output "forseti-server-service-account" {

--- a/test/fixtures/shared_vpc/main.tf
+++ b/test/fixtures/shared_vpc/main.tf
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+provider "tls" {
+  version = "~> 1.2"
+}
+
 resource "tls_private_key" "main" {
   algorithm = "RSA"
   rsa_bits  = 4096
@@ -22,6 +26,13 @@ resource "tls_private_key" "main" {
 resource "local_file" "gce-keypair-pk" {
   content  = "${tls_private_key.main.private_key_pem}"
   filename = "${path.module}/sshkey"
+}
+
+module "bastion" {
+  source     = "../bastion"
+  project_id = "${var.project_id}"
+  subnetwork = "default"
+  zone       = "us-central1-f"
 }
 
 module "forseti-shared-vpc" {
@@ -50,9 +61,14 @@ resource "null_resource" "wait_for_server" {
     script = "${path.module}/scripts/wait-for-forseti.sh"
 
     connection {
-      user        = "ubuntu"
-      host        = "${module.forseti-shared-vpc.forseti-server-vm-public-ip}"
-      private_key = "${tls_private_key.main.private_key_pem}"
+      type                = "ssh"
+      user                = "ubuntu"
+      host                = "${module.forseti-shared-vpc.forseti-server-vm-ip}"
+      private_key         = "${tls_private_key.main.private_key_pem}"
+      bastion_host        = "${module.bastion.host}"
+      bastion_port        = "${module.bastion.port}"
+      bastion_private_key = "${module.bastion.private_key}"
+      bastion_user        = "${module.bastion.user}"
     }
   }
 }
@@ -66,9 +82,14 @@ resource "null_resource" "wait_for_client" {
     script = "${path.module}/scripts/wait-for-forseti.sh"
 
     connection {
-      user        = "ubuntu"
-      host        = "${module.forseti-shared-vpc.forseti-client-vm-public-ip}"
-      private_key = "${tls_private_key.main.private_key_pem}"
+      type                = "ssh"
+      user                = "ubuntu"
+      host                = "${module.forseti-shared-vpc.forseti-client-vm-ip}"
+      private_key         = "${tls_private_key.main.private_key_pem}"
+      bastion_host        = "${module.bastion.host}"
+      bastion_port        = "${module.bastion.port}"
+      bastion_private_key = "${module.bastion.private_key}"
+      bastion_user        = "${module.bastion.user}"
     }
   }
 }

--- a/test/fixtures/shared_vpc/outputs.tf
+++ b/test/fixtures/shared_vpc/outputs.tf
@@ -29,11 +29,6 @@ output "forseti-server-vm-ip" {
   value       = "${module.forseti-shared-vpc.forseti-server-vm-ip}"
 }
 
-output "forseti-server-vm-public-ip" {
-  description = "Forseti Server VM public IP address"
-  value       = "${module.forseti-shared-vpc.forseti-server-vm-public-ip}"
-}
-
 output "forseti-server-vm-name" {
   description = "Forseti Server VM name"
   value       = "${module.forseti-shared-vpc.forseti-server-vm-name}"
@@ -42,11 +37,6 @@ output "forseti-server-vm-name" {
 output "forseti-client-vm-ip" {
   description = "Forseti Client VM private IP address"
   value       = "${module.forseti-shared-vpc.forseti-client-vm-ip}"
-}
-
-output "forseti-client-vm-public-ip" {
-  description = "Forseti Client VM public IP address"
-  value       = "${module.forseti-shared-vpc.forseti-client-vm-public-ip}"
 }
 
 output "forseti-client-vm-name" {

--- a/test/integration/simple_example/controls/server.rb
+++ b/test/integration/simple_example/controls/server.rb
@@ -330,6 +330,15 @@ control "server" do
           )
         end
 
+        it "configures violations_slack_webhook" do
+          expect(config["notifier"]["resources"]).to include(
+            including(
+              "resource" => "config_validator_violations",
+              "notifiers" => including("name" => "slack_webhook", "configuration" => { "data_format" => "json", "webhook_url" => nil }),
+            )
+          )
+        end
+
         it "configures audit_logging_violations_should_notify" do
           expect(config["notifier"]["resources"]).to include(including("resource" => "audit_logging_violations", "should_notify" => true))
         end

--- a/variables.tf
+++ b/variables.tf
@@ -432,6 +432,11 @@ variable "service_account_key_enabled" {
 #--------------------------------#
 # Forseti server config notifier #
 #--------------------------------#
+variable "violations_slack_webhook" {
+  description = "Slack webhook for any violation. Will apply to all scanner violation notifiers."
+  default     = ""
+}
+
 variable "iam_policy_violations_should_notify" {
   description = "Notify for IAM Policy violations"
   default     = "true"


### PR DESCRIPTION
Defines the new `violations_slack_webhook` variable which  configures the slack
webhook for all notifiers. Per notifier slack hooks are unlikely to be useful. The existing per notifier hooks
`iam_policy_violations_slack_webhook` and `kms_violations_slack_webhook` still work and
take precedence over this new variable if both are defined.