### PR TITLE
Remove public IP outputs

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -98,7 +98,7 @@ suites:
           user: ubuntu
           key_files:
             - test/fixtures/shared_vpc/sshkey
-          proxy_command: ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -o LogLevel=ERROR -o ForwardAgent=no -i test/fixtures/bastion/tls_private_key ubuntu@<%= `terraform output -state test/fixtures/shared_vpc/terraform.tfstate.d/kitchen-terraform-simple-example-local/terraform.tfstate bastion_host`.strip %> -p 22 -W %h:%p
+          proxy_command: ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -o LogLevel=ERROR -o ForwardAgent=no -i test/fixtures/bastion/tls_private_key ubuntu@<%= `terraform output -state test/fixtures/shared_vpc/terraform.tfstate.d/kitchen-terraform-shared-vpc-local/terraform.tfstate bastion_host`.strip %> -p 22 -W %h:%p
           shell: true
           shell_options: "--login"
         - name: forseti-client
@@ -110,7 +110,7 @@ suites:
           user: ubuntu
           key_files:
             - test/fixtures/shared_vpc/sshkey
-          proxy_command: ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -o LogLevel=ERROR -o ForwardAgent=no -i test/fixtures/bastion/tls_private_key ubuntu@<%= `terraform output -state test/fixtures/shared_vpc/terraform.tfstate.d/kitchen-terraform-simple-example-local/terraform.tfstate bastion_host`.strip %> -p 22 -W %h:%p
+          proxy_command: ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -o LogLevel=ERROR -o ForwardAgent=no -i test/fixtures/bastion/tls_private_key ubuntu@<%= `terraform output -state test/fixtures/shared_vpc/terraform.tfstate.d/kitchen-terraform-shared-vpc-local/terraform.tfstate bastion_host`.strip %> -p 22 -W %h:%p
           shell: true
           shell_options: "--login"
     provisioner:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -94,10 +94,11 @@ suites:
           controls:
             - forseti-command-server
             - server
-          hosts_output: forseti-server-vm-public-ip
+          hosts_output: forseti-server-vm-ip
           user: ubuntu
           key_files:
             - test/fixtures/shared_vpc/sshkey
+          proxy_command: ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -o LogLevel=ERROR -o ForwardAgent=no -i test/fixtures/bastion/tls_private_key ubuntu@<%= `terraform output -state test/fixtures/shared_vpc/terraform.tfstate.d/kitchen-terraform-simple-example-local/terraform.tfstate bastion_host`.strip %> -p 22 -W %h:%p
           shell: true
           shell_options: "--login"
         - name: forseti-client
@@ -105,10 +106,11 @@ suites:
           controls:
             - forseti-command-client
             - client
-          hosts_output: forseti-client-vm-public-ip
+          hosts_output: forseti-client-vm-ip
           user: ubuntu
           key_files:
             - test/fixtures/shared_vpc/sshkey
+          proxy_command: ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -o LogLevel=ERROR -o ForwardAgent=no -i test/fixtures/bastion/tls_private_key ubuntu@<%= `terraform output -state test/fixtures/shared_vpc/terraform.tfstate.d/kitchen-terraform-simple-example-local/terraform.tfstate bastion_host`.strip %> -p 22 -W %h:%p
           shell: true
           shell_options: "--login"
     provisioner:

--- a/README.md
+++ b/README.md
@@ -182,12 +182,10 @@ Then perform the following commands on the config folder:
 | forseti-client-storage-bucket | Forseti Client storage bucket |
 | forseti-client-vm-ip | Forseti Client VM private IP address |
 | forseti-client-vm-name | Forseti Client VM name |
-| forseti-client-vm-public-ip | Forseti Server VM public IP address |
 | forseti-server-service-account | Forseti Server service account |
 | forseti-server-storage-bucket | Forseti Server storage bucket |
 | forseti-server-vm-ip | Forseti Server VM private IP address |
 | forseti-server-vm-name | Forseti Server VM name |
-| forseti-server-vm-public-ip | Forseti Server VM public IP address |
 | suffix | The random suffix appended to Forseti resources |
 
 [^]: (autogen_docs_end)

--- a/examples/external_ip/README.md
+++ b/examples/external_ip/README.md
@@ -22,12 +22,10 @@ This example illustrates how to set up a minimal Forseti installation.
 
 | Name | Description |
 |------|-------------|
-| forseti-client-public-ip | Forseti Client VM public IP address |
 | forseti-client-service-account | Forseti Client service account |
 | forseti-client-storage-bucket | Forseti Client storage bucket |
 | forseti-client-vm-ip | Forseti Client VM private IP address |
 | forseti-client-vm-name | Forseti Client VM name |
-| forseti-server-public-ip | Forseti Server VM public IP address |
 | forseti-server-service-account | Forseti Server service account |
 | forseti-server-storage-bucket | Forseti Server storage bucket |
 | forseti-server-vm-ip | Forseti Server VM private IP address |

--- a/examples/external_ip/README.md
+++ b/examples/external_ip/README.md
@@ -26,6 +26,7 @@ This example illustrates how to set up a minimal Forseti installation.
 | forseti-client-storage-bucket | Forseti Client storage bucket |
 | forseti-client-vm-ip | Forseti Client VM private IP address |
 | forseti-client-vm-name | Forseti Client VM name |
+| forseti-server-public-ip | Forseti Server VM public IP address |
 | forseti-server-service-account | Forseti Server service account |
 | forseti-server-storage-bucket | Forseti Server storage bucket |
 | forseti-server-vm-ip | Forseti Server VM private IP address |

--- a/examples/external_ip/outputs.tf
+++ b/examples/external_ip/outputs.tf
@@ -39,6 +39,11 @@ output "forseti-server-vm-ip" {
   value       = "${module.forseti-install-simple.forseti-server-vm-ip}"
 }
 
+output "forseti-server-public-ip" {
+  description = "Forseti Server VM public IP address"
+  value       = "${google_compute_address.forseti_server_ip.address}"
+}
+
 output "forseti-server-service-account" {
   description = "Forseti Server service account"
   value       = "${module.forseti-install-simple.forseti-server-service-account}"

--- a/examples/external_ip/outputs.tf
+++ b/examples/external_ip/outputs.tf
@@ -24,11 +24,6 @@ output "forseti-client-vm-ip" {
   value       = "${module.forseti-install-simple.forseti-client-vm-ip}"
 }
 
-output "forseti-client-public-ip" {
-  description = "Forseti Client VM public IP address"
-  value       = "${google_compute_address.forseti_client_ip.address}"
-}
-
 output "forseti-client-service-account" {
   description = "Forseti Client service account"
   value       = "${module.forseti-install-simple.forseti-client-service-account}"
@@ -42,11 +37,6 @@ output "forseti-server-vm-name" {
 output "forseti-server-vm-ip" {
   description = "Forseti Server VM private IP address"
   value       = "${module.forseti-install-simple.forseti-server-vm-ip}"
-}
-
-output "forseti-server-public-ip" {
-  description = "Forseti Server VM public IP address"
-  value       = "${google_compute_address.forseti_server_ip.address}"
 }
 
 output "forseti-server-service-account" {

--- a/examples/shared_vpc/README.md
+++ b/examples/shared_vpc/README.md
@@ -28,12 +28,10 @@ This example illustrates how to set up a Forseti installation with shared VPC.
 | forseti-client-storage-bucket | Forseti Client storage bucket |
 | forseti-client-vm-ip | Forseti Client VM private IP address |
 | forseti-client-vm-name | Forseti Client VM name |
-| forseti-client-vm-public-ip | Forseti Client VM public IP address |
 | forseti-server-service-account | Forseti Server service account |
 | forseti-server-storage-bucket | Forseti Server storage bucket |
 | forseti-server-vm-ip | Forseti Server VM private IP address |
 | forseti-server-vm-name | Forseti Server VM name |
-| forseti-server-vm-public-ip | Forseti Server VM public IP address |
 | network | Network where server and client will be deployed |
 | network\_project | ID of the network project holding shared VPC |
 | project\_id | ID of the service project |

--- a/examples/shared_vpc/outputs.tf
+++ b/examples/shared_vpc/outputs.tf
@@ -34,11 +34,6 @@ output "forseti-server-vm-ip" {
   value       = "${module.forseti.forseti-server-vm-ip}"
 }
 
-output "forseti-server-vm-public-ip" {
-  description = "Forseti Server VM public IP address"
-  value       = "${module.forseti.forseti-server-vm-public-ip}"
-}
-
 output "forseti-server-vm-name" {
   description = "Forseti Server VM name"
   value       = "${module.forseti.forseti-server-vm-name}"
@@ -47,11 +42,6 @@ output "forseti-server-vm-name" {
 output "forseti-client-vm-ip" {
   description = "Forseti Client VM private IP address"
   value       = "${module.forseti.forseti-client-vm-ip}"
-}
-
-output "forseti-client-vm-public-ip" {
-  description = "Forseti Client VM public IP address"
-  value       = "${module.forseti.forseti-client-vm-public-ip}"
 }
 
 output "forseti-client-vm-name" {

--- a/modules/client/outputs.tf
+++ b/modules/client/outputs.tf
@@ -24,11 +24,6 @@ output "forseti-client-vm-ip" {
   value       = "${google_compute_instance.forseti-client.network_interface.0.network_ip}"
 }
 
-output "forseti-client-vm-public-ip" {
-  description = "Forseti Client VM public IP address"
-  value       = "${google_compute_instance.forseti-client.network_interface.0.access_config.0.nat_ip}"
-}
-
 output "forseti-client-service-account" {
   description = "Forseti Client service account"
   value       = "${google_service_account.forseti_client.email}"

--- a/modules/server/outputs.tf
+++ b/modules/server/outputs.tf
@@ -24,11 +24,6 @@ output "forseti-server-vm-ip" {
   value       = "${google_compute_instance.forseti-server.network_interface.0.network_ip}"
 }
 
-output "forseti-server-vm-public-ip" {
-  description = "Forseti Server VM public IP address"
-  value       = "${google_compute_instance.forseti-server.network_interface.0.access_config.0.nat_ip}"
-}
-
 output "forseti-server-service-account" {
   description = "Forseti Server service account"
   value       = "${google_service_account.forseti_server.email}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -24,11 +24,6 @@ output "forseti-server-vm-ip" {
   value       = "${module.server.forseti-server-vm-ip}"
 }
 
-output "forseti-server-vm-public-ip" {
-  description = "Forseti Server VM public IP address"
-  value       = "${module.server.forseti-server-vm-public-ip}"
-}
-
 output "forseti-client-vm-name" {
   description = "Forseti Client VM name"
   value       = "${module.client.forseti-client-vm-name}"
@@ -37,11 +32,6 @@ output "forseti-client-vm-name" {
 output "forseti-client-vm-ip" {
   description = "Forseti Client VM private IP address"
   value       = "${module.client.forseti-client-vm-ip}"
-}
-
-output "forseti-client-vm-public-ip" {
-  description = "Forseti Server VM public IP address"
-  value       = "${module.client.forseti-client-vm-public-ip}"
 }
 
 output "forseti-server-service-account" {

--- a/test/fixtures/shared_vpc/main.tf
+++ b/test/fixtures/shared_vpc/main.tf
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+provider "tls" {
+  version = "~> 1.2"
+}
+
 resource "tls_private_key" "main" {
   algorithm = "RSA"
   rsa_bits  = 4096
@@ -22,6 +26,13 @@ resource "tls_private_key" "main" {
 resource "local_file" "gce-keypair-pk" {
   content  = "${tls_private_key.main.private_key_pem}"
   filename = "${path.module}/sshkey"
+}
+
+module "bastion" {
+  source     = "../bastion"
+  project_id = "${var.project_id}"
+  subnetwork = "default"
+  zone       = "us-central1-f"
 }
 
 module "forseti-shared-vpc" {
@@ -50,9 +61,14 @@ resource "null_resource" "wait_for_server" {
     script = "${path.module}/scripts/wait-for-forseti.sh"
 
     connection {
-      user        = "ubuntu"
-      host        = "${module.forseti-shared-vpc.forseti-server-vm-public-ip}"
-      private_key = "${tls_private_key.main.private_key_pem}"
+      type                = "ssh"
+      user                = "ubuntu"
+      host                = "${module.forseti-shared-vpc.forseti-server-vm-ip}"
+      private_key         = "${tls_private_key.main.private_key_pem}"
+      bastion_host        = "${module.bastion.host}"
+      bastion_port        = "${module.bastion.port}"
+      bastion_private_key = "${module.bastion.private_key}"
+      bastion_user        = "${module.bastion.user}"
     }
   }
 }
@@ -66,9 +82,14 @@ resource "null_resource" "wait_for_client" {
     script = "${path.module}/scripts/wait-for-forseti.sh"
 
     connection {
-      user        = "ubuntu"
-      host        = "${module.forseti-shared-vpc.forseti-client-vm-public-ip}"
-      private_key = "${tls_private_key.main.private_key_pem}"
+      type                = "ssh"
+      user                = "ubuntu"
+      host                = "${module.forseti-shared-vpc.forseti-client-vm-ip}"
+      private_key         = "${tls_private_key.main.private_key_pem}"
+      bastion_host        = "${module.bastion.host}"
+      bastion_port        = "${module.bastion.port}"
+      bastion_private_key = "${module.bastion.private_key}"
+      bastion_user        = "${module.bastion.user}"
     }
   }
 }

--- a/test/fixtures/shared_vpc/outputs.tf
+++ b/test/fixtures/shared_vpc/outputs.tf
@@ -29,11 +29,6 @@ output "forseti-server-vm-ip" {
   value       = "${module.forseti-shared-vpc.forseti-server-vm-ip}"
 }
 
-output "forseti-server-vm-public-ip" {
-  description = "Forseti Server VM public IP address"
-  value       = "${module.forseti-shared-vpc.forseti-server-vm-public-ip}"
-}
-
 output "forseti-server-vm-name" {
   description = "Forseti Server VM name"
   value       = "${module.forseti-shared-vpc.forseti-server-vm-name}"
@@ -42,11 +37,6 @@ output "forseti-server-vm-name" {
 output "forseti-client-vm-ip" {
   description = "Forseti Client VM private IP address"
   value       = "${module.forseti-shared-vpc.forseti-client-vm-ip}"
-}
-
-output "forseti-client-vm-public-ip" {
-  description = "Forseti Client VM public IP address"
-  value       = "${module.forseti-shared-vpc.forseti-client-vm-public-ip}"
 }
 
 output "forseti-client-vm-name" {


### PR DESCRIPTION
This essentially reverts #149 and adds a bastion hosts to the `shared_vpc` example to make tests pass.