### PR TITLE
Change to pip3 and python3

### DIFF
--- a/modules/client/templates/scripts/forseti-client/forseti_client_startup_script.sh.tpl
+++ b/modules/client/templates/scripts/forseti-client/forseti_client_startup_script.sh.tpl
@@ -32,9 +32,8 @@ git checkout ${forseti_version}
 sudo apt-get install -y $(cat install/dependencies/apt_packages.txt | grep -v "#" | xargs)
 
 # Forseti dependencies
-pip3 install --upgrade pip==19.1.1
-pip3 install -q --upgrade setuptools wheel
-pip3 install -q --upgrade -r requirements.txt
+python3 -m pip install -q --upgrade setuptools wheel
+python3 -m pip install -q --upgrade -r requirements.txt
 
 # Install Forseti
 echo "Installing Forseti"

--- a/modules/client/templates/scripts/forseti-client/forseti_client_startup_script.sh.tpl
+++ b/modules/client/templates/scripts/forseti-client/forseti_client_startup_script.sh.tpl
@@ -32,13 +32,13 @@ git checkout ${forseti_version}
 sudo apt-get install -y $(cat install/dependencies/apt_packages.txt | grep -v "#" | xargs)
 
 # Forseti dependencies
-pip install --upgrade pip==9.0.3
-pip install -q --upgrade setuptools wheel
-pip install -q --upgrade -r requirements.txt
+pip3 install --upgrade pip==19.1.1
+pip3 install -q --upgrade setuptools wheel
+pip3 install -q --upgrade -r requirements.txt
 
 # Install Forseti
 echo "Installing Forseti"
-python setup.py install
+python3 setup.py install
 
 # Set ownership of the forseti project to $USER
 chown -R $USER ${forseti_home}

--- a/modules/client/templates/scripts/forseti-client/forseti_client_startup_script.sh.tpl
+++ b/modules/client/templates/scripts/forseti-client/forseti_client_startup_script.sh.tpl
@@ -32,7 +32,7 @@ git checkout ${forseti_version}
 sudo apt-get install -y $(cat install/dependencies/apt_packages.txt | grep -v "#" | xargs)
 
 # Forseti dependencies
-pip3 install --upgrade pip==9.0.3
+pip3 install --upgrade pip==19.1.1
 pip3 install -q --upgrade setuptools wheel
 pip3 install -q --upgrade -r requirements.txt
 

--- a/modules/client/templates/scripts/forseti-client/forseti_client_startup_script.sh.tpl
+++ b/modules/client/templates/scripts/forseti-client/forseti_client_startup_script.sh.tpl
@@ -32,7 +32,7 @@ git checkout ${forseti_version}
 sudo apt-get install -y $(cat install/dependencies/apt_packages.txt | grep -v "#" | xargs)
 
 # Forseti dependencies
-pip3 install --upgrade pip==19.1.1
+pip3 install --upgrade pip==9.0.3
 pip3 install -q --upgrade setuptools wheel
 pip3 install -q --upgrade -r requirements.txt
 

--- a/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
+++ b/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
@@ -43,9 +43,9 @@ git checkout ${forseti_version}
 sudo apt-get install -y $(cat install/dependencies/apt_packages.txt | grep -v "#" | xargs)
 
 # Forseti dependencies
-pip install --upgrade pip==9.0.3
-pip install -q --upgrade setuptools wheel
-pip install -q --upgrade -r requirements.txt
+pip3 install --upgrade pip==19.1.1
+pip3 install -q --upgrade setuptools wheel
+pip3 install -q --upgrade -r requirements.txt
 
 # Setup Forseti logging
 touch /var/log/forseti.log
@@ -61,7 +61,7 @@ chmod -R ug+rwx ${forseti_home}/configs ${forseti_home}/rules ${forseti_home}/in
 
 # Install Forseti
 echo "Installing Forseti"
-python setup.py install
+python3 setup.py install
 
 # Export variables required by initialize_forseti_services.sh.
 ${forseti_env}
@@ -93,7 +93,7 @@ systemctl start config-validator
 sleep 5
 
 echo "Attempting to update database schema, if necessary."
-python $USER_HOME/forseti-security/install/gcp/upgrade_tools/db_migrator.py
+python3 $USER_HOME/forseti-security/install/gcp/upgrade_tools/db_migrator.py
 
 systemctl start forseti
 echo "Success! The Forseti API server has been started."

--- a/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
+++ b/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
@@ -43,7 +43,7 @@ git checkout ${forseti_version}
 sudo apt-get install -y $(cat install/dependencies/apt_packages.txt | grep -v "#" | xargs)
 
 # Forseti dependencies
-pip3 install --upgrade pip==19.1.1
+pip3 install --upgrade pip==9.0.3
 pip3 install -q --upgrade setuptools wheel
 pip3 install -q --upgrade -r requirements.txt
 

--- a/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
+++ b/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
@@ -43,9 +43,8 @@ git checkout ${forseti_version}
 sudo apt-get install -y $(cat install/dependencies/apt_packages.txt | grep -v "#" | xargs)
 
 # Forseti dependencies
-pip3 install --upgrade pip==19.1.1
-pip3 install -q --upgrade setuptools wheel
-pip3 install -q --upgrade -r requirements.txt
+python3 -m pip install -q --upgrade setuptools wheel
+python3 -m pip install -q --upgrade -r requirements.txt
 
 # Setup Forseti logging
 touch /var/log/forseti.log

--- a/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
+++ b/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
@@ -43,7 +43,7 @@ git checkout ${forseti_version}
 sudo apt-get install -y $(cat install/dependencies/apt_packages.txt | grep -v "#" | xargs)
 
 # Forseti dependencies
-pip3 install --upgrade pip==9.0.3
+pip3 install --upgrade pip==19.1.1
 pip3 install -q --upgrade setuptools wheel
 pip3 install -q --upgrade -r requirements.txt
 


### PR DESCRIPTION
Change python/pip references to python3/pip3 to align with Python 3 migration efforts for v2.16.0.