### PR TITLE
Add Slack webhook support.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -232,6 +232,8 @@ module "server" {
   bigquery_acl_violations_should_notify               = "${var.bigquery_acl_violations_should_notify}"
   audit_logging_violations_should_notify              = "${var.audit_logging_violations_should_notify}"
 
+  violations_slack_webhook                            = "${var.violations_slack_webhook}"
+
   groups_settings_max_calls                = "${var.groups_settings_max_calls}"
   groups_settings_period                   = "${var.groups_settings_period}"
   groups_settings_disable_polling          = "${var.groups_settings_disable_polling}"

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -237,6 +237,8 @@ data "template_file" "forseti_server_config" {
     BIGQUERY_ACL_VIOLATIONS_SHOULD_NOTIFY               = "${var.bigquery_acl_violations_should_notify ? "true" : "false"}"
     AUDIT_LOGGING_VIOLATIONS_SHOULD_NOTIFY              = "${var.audit_logging_violations_should_notify ? "true" : "false"}"
 
+    VIOLATIONS_SLACK_WEBHOOK                            = "${var.violations_slack_webhook}"
+
     GROUPS_SETTINGS_MAX_CALLS                = "${var.groups_settings_max_calls}"
     GROUPS_SETTINGS_PERIOD                   = "${var.groups_settings_period}"
     GROUPS_SETTINGS_DISABLE_POLLING          = "${var.groups_settings_disable_polling ? "true" : "false"}"

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -242,7 +242,7 @@ data "template_file" "forseti_server_config" {
     AUDIT_LOGGING_VIOLATIONS_SHOULD_NOTIFY              = "${var.audit_logging_violations_should_notify ? "true" : "false"}"
 
     VIOLATIONS_SLACK_WEBHOOK                            = "${var.violations_slack_webhook}"
-    
+
     # CSCC notifications
     CSCC_VIOLATIONS_ENABLED = "${var.cscc_violations_enabled ? "true" : "false"}"
     CSCC_SOURCE_ID          = "${var.cscc_source_id}"

--- a/modules/server/templates/configs/forseti_conf_server.yaml.tpl
+++ b/modules/server/templates/configs/forseti_conf_server.yaml.tpl
@@ -285,10 +285,12 @@ notifier:
             # Create an incoming webhook in your organization's Slack setting, located at:
             # https://[your_org].slack.com/apps/manage/custom-integrations
             # Add the provided URL in the configuration below in `webhook_url`.
+            %{ if IAM_POLICY_VIOLATIONS_SLACK_WEBHOOK != "" || VIOLATIONS_SLACK_WEBHOOK != "" }
             - name: slack_webhook
               configuration:
                 data_format: json  # slack only supports json
-                webhook_url: ${IAM_POLICY_VIOLATIONS_SLACK_WEBHOOK}
+                webhook_url: %{ if IAM_POLICY_VIOLATIONS_SLACK_WEBHOOK != "" }${IAM_POLICY_VIOLATIONS_SLACK_WEBHOOK}%{ else }${VIOLATIONS_SLACK_WEBHOOK}%{ endif }
+            %{ endif }
 
         - resource: audit_logging_violations
           should_notify: ${AUDIT_LOGGING_VIOLATIONS_SHOULD_NOTIFY}
@@ -301,6 +303,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: blacklist_violations
           should_notify: ${BLACKLIST_VIOLATIONS_SHOULD_NOTIFY}
@@ -313,6 +321,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: bigquery_acl_violations
           should_notify: ${BIGQUERY_ACL_VIOLATIONS_SHOULD_NOTIFY}
@@ -325,6 +339,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: buckets_acl_violations
           should_notify: ${BUCKETS_ACL_VIOLATIONS_SHOULD_NOTIFY}
@@ -337,6 +357,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: config_validator_violations
           should_notify: ${CONFIG_VALIDATOR_VIOLATIONS_SHOULD_NOTIFY}
@@ -349,6 +375,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: cloudsql_acl_violations
           should_notify: ${CLOUDSQL_ACL_VIOLATIONS_SHOULD_NOTIFY}
@@ -361,6 +393,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: enabled_apis_violations
           should_notify: ${ENABLED_APIS_VIOLATIONS_SHOULD_NOTIFY}
@@ -373,6 +411,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: firewall_rule_violations
           should_notify: ${FIREWALL_RULE_VIOLATIONS_SHOULD_NOTIFY}
@@ -385,6 +429,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: forwarding_rule_violations
           should_notify: ${FORWARDING_RULE_VIOLATIONS_SHOULD_NOTIFY}
@@ -397,6 +447,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: groups_settings_violations
           should_notify: ${GROUPS_SETTINGS_VIOLATIONS_SHOULD_NOTIFY}
@@ -409,6 +465,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://{FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: ke_version_violations
           should_notify: ${KE_VERSION_VIOLATIONS_SHOULD_NOTIFY}
@@ -421,6 +483,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: ke_violations
           should_notify: ${KE_VIOLATIONS_SHOULD_NOTIFY}
@@ -433,6 +501,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: kms_violations
           should_notify: ${KMS_VIOLATIONS_SHOULD_NOTIFY}
@@ -449,10 +523,12 @@ notifier:
             # Create an incoming webhook in your organization's Slack setting, located at:
             # https://[your_org].slack.com/apps/manage/custom-integrations
             # Add the provided URL in the configuration below in `webhook_url`.
+            %{ if KMS_VIOLATIONS_SLACK_WEBHOOK != "" || VIOLATIONS_SLACK_WEBHOOK != "" }
             - name: slack_webhook
               configuration:
                 data_format: json  # slack only supports json
-                webhook_url: ${KMS_VIOLATIONS_SLACK_WEBHOOK}
+                webhook_url: %{ if KMS_VIOLATIONS_SLACK_WEBHOOK != "" }${KMS_VIOLATIONS_SLACK_WEBHOOK}%{ else }${VIOLATIONS_SLACK_WEBHOOK}%{ endif }
+            %{ endif }
 
         - resource: groups_violations
           should_notify: ${GROUPS_VIOLATIONS_SHOULD_NOTIFY}
@@ -465,6 +541,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: instance_network_interface_violations
           should_notify: ${INSTANCE_NETWORK_INTERFACE_VIOLATIONS_SHOULD_NOTIFY}
@@ -477,6 +559,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: iap_violations
           should_notify: ${IAP_VIOLATIONS_SHOULD_NOTIFY}
@@ -489,6 +577,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: lien_violations
           should_notify: ${LIEN_VIOLATIONS_SHOULD_NOTIFY}
@@ -501,6 +595,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: location_violations
           should_notify: ${LOCATION_VIOLATIONS_SHOULD_NOTIFY}
@@ -513,6 +613,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: log_sink_violations
           should_notify: ${LOG_SINK_VIOLATIONS_SHOULD_NOTIFY}
@@ -525,6 +631,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: resource_violations
           should_notify: ${RESOURCE_VIOLATIONS_SHOULD_NOTIFY}
@@ -537,6 +649,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: service_account_key_violations
           should_notify: ${SERVICE_ACCOUNT_KEY_VIOLATIONS_SHOULD_NOTIFY}
@@ -549,6 +667,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
         - resource: external_project_access_violations
           should_notify: ${EXTERNAL_PROJECT_ACCESS_VIOLATIONS_SHOULD_NOTIFY}
@@ -561,6 +685,12 @@ notifier:
                 data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://${FORSETI_BUCKET}/scanner_violations
+            %{ if VIOLATIONS_SLACK_WEBHOOK != "" }
+            - name: slack_webhook
+              configuration:
+                data_format: json  # slack only supports json
+                webhook_url: ${VIOLATIONS_SLACK_WEBHOOK}
+            %{ endif }
 
     violation:
       cscc:

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -379,6 +379,11 @@ variable "service_account_key_enabled" {
 #-------------------------#
 # Forseti config notifier #
 #-------------------------#
+variable "violations_slack_webhook" {
+  description = "Slack webhook for any violation. Will apply to all scanner violation notifiers."
+  default     = ""
+}
+
 variable "iam_policy_violations_should_notify" {
   description = "Notify for IAM Policy violations"
   default     = "true"

--- a/test/integration/simple_example/controls/server.rb
+++ b/test/integration/simple_example/controls/server.rb
@@ -324,8 +324,6 @@ control "server" do
             including(
               "resource" => "iam_policy_violations",
               "should_notify" => true,
-              # This extra bit of verification tests the `iam_policy_violations_slack_webhook` variable
-              "notifiers" => including("name" => "slack_webhook", "configuration" => { "data_format" => "json", "webhook_url" => nil }),
             )
           )
         end

--- a/test/integration/simple_example/controls/server.rb
+++ b/test/integration/simple_example/controls/server.rb
@@ -374,8 +374,6 @@ control "server" do
             including(
               "resource" => "kms_violations",
               "should_notify" => true,
-              # This extra bit of verification tests the `kms_violations_slack_webhook` variable
-              "notifiers" => including("name" => "slack_webhook", "configuration" => { "data_format" => "json", "webhook_url" => nil }),
             )
           )
         end

--- a/variables.tf
+++ b/variables.tf
@@ -432,6 +432,11 @@ variable "service_account_key_enabled" {
 #--------------------------------#
 # Forseti server config notifier #
 #--------------------------------#
+variable "violations_slack_webhook" {
+  description = "Slack webhook for any violation. Will apply to all scanner violation notifiers."
+  default     = ""
+}
+
 variable "iam_policy_violations_should_notify" {
   description = "Notify for IAM Policy violations"
   default     = "true"


### PR DESCRIPTION
Defines the new `violations_slack_webhook` variable which will configure a slack
webhook for all notifiers. The expectation is that per notifier slack hooks are
unlikely to be useful. The existing `iam_policy_violations_slack_webhook` and `kms_violations_slack_webhook` still work and
take precedence over this new variable if both are defined.