### PR TITLE
Add private IP config to Forseti enforcer VM

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -131,6 +131,7 @@ suites:
   - name: real_time_enforcer
     lifecycle:
       pre_verify:
+        - local: chmod go-rwx test/fixtures/bastion/tls_private_key
         - local: test/fixtures/real_time_enforcer/modules/enforcer_target/helpers/create-enforcer-fixtures.sh
       post_destroy:
         - local: test/fixtures/real_time_enforcer/modules/enforcer_target/helpers/destroy-enforcer-fixtures.sh

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -150,10 +150,11 @@ suites:
           backend: ssh
           controls:
             - real-time-enforcer-host
-          hosts_output: forseti-rt-enforcer-vm-public-ip
+          hosts_output: forseti-rt-enforcer-vm-ip
           user: ubuntu
           key_files:
             - test/fixtures/real_time_enforcer/sshkey
+          proxy_command: ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -o LogLevel=ERROR -o ForwardAgent=no -i test/fixtures/bastion/tls_private_key ubuntu@<%= `terraform output -state test/fixtures/real_time_enforcer/terraform.tfstate.d/kitchen-terraform-real-time-enforcer-local/terraform.tfstate bastion_host`.strip %> -p 22 -W %h:%p
           shell: true
           shell_options: "--login"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ Extending the adopted spec, each change should have a link to its corresponding 
 ### Changed
 - Do not add email configuration if `sendgrid_api_key` is unset [#174]
 
-
 ## [v2.1.0] - 2019-05-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,21 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Extending the adopted spec, each change should have a link to its corresponding pull request appended.
 
+## Unreleased
+
+- Make Forseti Real-Time Enforcer VM have private IP by default. [#180]
+- Do not add email configuration if `sendgrid_api_key` is unset [#174]
+
 ## [v2.2.0] - 2019-06-20
 
 ### Added
 
 - Support for Forseti v2.17.0 [#184]
 - Add Kubernetes resources to CAI asset inventory
-
-### Changed
-
-- Make Forseti Real-Time Enforcer VM have private IP by default. [#180]
-- Do not add email configuration if `sendgrid_api_key` is unset [#174]
-
-### Changed
-
-- Make Forseti Real-Time Enforcer VM have private IP by default
 
 ## [v2.1.0] - 2019-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Extending the adopted spec, each change should have a link to its corresponding 
 ### Added
 
 - Add 50052 port in Firewall rule for Config Validator. [#155]
-- Check for both empty values org_id and folder_id [#152]
+- Check for both empty values org_id and folder_id. [#152]
 
 ## [v1.6.0] - 2019-05-14
 
@@ -162,6 +162,7 @@ Extending the adopted spec, each change should have a link to its corresponding 
 [v1.6.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v1.5.1...v1.6.0
 
 [#155]: https://github.com/forseti-security/terraform-google-forseti/pull/155
+[#152]: https://github.com/forseti-security/terraform-google-forseti/pull/152
 [#146]: https://github.com/terraform-google-modules/terraform-google-forseti/pull/146
 [#145]: https://github.com/terraform-google-modules/terraform-google-forseti/pull/145
 [#137]: https://github.com/terraform-google-modules/terraform-google-forseti/pull/137

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Extending the adopted spec, each change should have a link to its corresponding 
 - Add Kubernetes resources to CAI asset inventory
 
 ### Changed
+
 - Do not add email configuration if `sendgrid_api_key` is unset [#174]
 
 ## [v2.1.0] - 2019-05-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,7 @@ Extending the adopted spec, each change should have a link to its corresponding 
 [v2.0.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v1.6.0...v2.0.0
 [v2.1.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v2.0.0...v2.1.0
 
+[#170]: https://github.com/forseti-security/terraform-google-forseti/pull/170
 [#163]: https://github.com/forseti-security/terraform-google-forseti/pull/163
 [#157]: https://github.com/forseti-security/terraform-google-forseti/pull/157
 [#158]: https://github.com/forseti-security/terraform-google-forseti/pull/158

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,7 @@ Extending the adopted spec, each change should have a link to its corresponding 
 [v1.5.1]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v1.5.0...v1.5.1
 [v1.6.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v1.5.1...v1.6.0
 [v2.0.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v1.6.0...v2.0.0
+[v2.1.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v2.0.0...v2.1.0
 
 [#163]: https://github.com/forseti-security/terraform-google-forseti/pull/163
 [#157]: https://github.com/forseti-security/terraform-google-forseti/pull/157

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,13 @@ Extending the adopted spec, each change should have a link to its corresponding 
 
 ### Added
 
+- Enable CSCC API when violations are enabled. [#158]
 - Add 50052 port in Firewall rule for Config Validator. [#155]
 - Check for both empty values org_id and folder_id. [#152]
+
+### Changed
+
+- Updated server firewall rule to restrict by service accounts. [#157]
 
 ## [v1.6.0] - 2019-05-14
 
@@ -161,6 +166,8 @@ Extending the adopted spec, each change should have a link to its corresponding 
 [v1.5.1]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v1.5.0...v1.5.1
 [v1.6.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v1.5.1...v1.6.0
 
+[#157]: https://github.com/forseti-security/terraform-google-forseti/pull/157
+[#158]: https://github.com/forseti-security/terraform-google-forseti/pull/158
 [#155]: https://github.com/forseti-security/terraform-google-forseti/pull/155
 [#152]: https://github.com/forseti-security/terraform-google-forseti/pull/152
 [#146]: https://github.com/terraform-google-modules/terraform-google-forseti/pull/146

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ Extending the adopted spec, each change should have a link to its corresponding 
 ## Unreleased
 
 - Make Forseti Real-Time Enforcer VM have private IP by default. [#180]
-- Do not add email configuration if `sendgrid_api_key` is unset [#174]
 
 ## [v2.2.0] - 2019-06-20
 
@@ -17,6 +16,10 @@ Extending the adopted spec, each change should have a link to its corresponding 
 
 - Support for Forseti v2.17.0 [#184]
 - Add Kubernetes resources to CAI asset inventory
+
+### Changed
+- Do not add email configuration if `sendgrid_api_key` is unset [#174]
+
 
 ## [v2.1.0] - 2019-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Extending the adopted spec, each change should have a link to its corresponding 
 
 ## [Unreleased]
 
+### Changed
+
+- Make Forseti Real-Time Enforcer VM have private IP by default
+
 ## [v2.1.0] - 2019-05-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A simple setup is provided in the examples folder; however, the usage of the mod
 
     module "forseti" {
       source  = "terraform-google-modules/forseti/google"
-      version = "~> 1.2"
+      version = "~> 2.0.0"
 
       gsuite_admin_email = "superadmin@yourdomain.com"
       domain             = "yourdomain.com"

--- a/examples/real_time_enforcer/README.md
+++ b/examples/real_time_enforcer/README.md
@@ -24,7 +24,6 @@ This example illustrates how to set up a Forseti installation with real-time pol
 | forseti-rt-enforcer-viewer-role-id | The forseti real time enforcer viewer Role ID. |
 | forseti-rt-enforcer-vm-ip | Forseti Enforcer VM private IP address |
 | forseti-rt-enforcer-vm-name | Forseti Enforcer VM name |
-| forseti-rt-enforcer-vm-public-ip | Forseti Enforcer VM public IP address |
 | forseti-rt-enforcer-writer-role-id | The forseti real time enforcer writer Role ID. |
 | suffix | The random suffix appended to Forseti resources |
 

--- a/examples/real_time_enforcer/main.tf
+++ b/examples/real_time_enforcer/main.tf
@@ -41,28 +41,26 @@ resource "random_string" "suffix" {
 
 module "real_time_enforcer_roles" {
   source = "../../modules/real_time_enforcer_roles"
-
   org_id = "${var.org_id}"
   suffix = "${random_string.suffix.result}"
 }
 
 module "real_time_enforcer_project_sink" {
-  source = "../../modules/real_time_enforcer_project_sink"
-
+  source            = "../../modules/real_time_enforcer_project_sink"
   pubsub_project_id = "${var.project_id}"
   sink_project_id   = "${var.enforcer_project_id}"
 }
 
 module "real_time_enforcer" {
-  source = "../../modules/real_time_enforcer"
-
+  source                     = "../../modules/real_time_enforcer"
   project_id                 = "${var.project_id}"
   org_id                     = "${var.org_id}"
   enforcer_instance_metadata = "${var.instance_metadata}"
   topic                      = "${module.real_time_enforcer_project_sink.topic}"
-
-  enforcer_viewer_role = "${module.real_time_enforcer_roles.forseti-rt-enforcer-viewer-role-id}"
-  enforcer_writer_role = "${module.real_time_enforcer_roles.forseti-rt-enforcer-writer-role-id}"
-  enforce_private_instance = "true"
-  suffix = "${random_string.suffix.result}"
+  enforcer_viewer_role       = "${module.real_time_enforcer_roles.forseti-rt-enforcer-viewer-role-id}"
+  enforcer_writer_role       = "${module.real_time_enforcer_roles.forseti-rt-enforcer-writer-role-id}"
+  enforcer_instance_private  = "true"
+  suffix                     = "${random_string.suffix.result}"
+  network                    = "${google_compute_router.main.network}"
+  subnetwork                 = "${data.google_compute_subnetwork.main.name}"
 }

--- a/examples/real_time_enforcer/main.tf
+++ b/examples/real_time_enforcer/main.tf
@@ -63,6 +63,6 @@ module "real_time_enforcer" {
 
   enforcer_viewer_role = "${module.real_time_enforcer_roles.forseti-rt-enforcer-viewer-role-id}"
   enforcer_writer_role = "${module.real_time_enforcer_roles.forseti-rt-enforcer-writer-role-id}"
-
+  enforce_private_instance = "true"
   suffix = "${random_string.suffix.result}"
 }

--- a/examples/real_time_enforcer/nat.tf
+++ b/examples/real_time_enforcer/nat.tf
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 resource "random_pet" "main" {
   length    = "1"
   prefix    = "forseti-simple-example"

--- a/examples/real_time_enforcer/nat.tf
+++ b/examples/real_time_enforcer/nat.tf
@@ -1,0 +1,38 @@
+resource "random_pet" "main" {
+  length    = "1"
+  prefix    = "forseti-simple-example"
+  separator = "-"
+}
+
+resource "google_compute_router" "main" {
+  name    = "${random_pet.main.id}"
+  network = "default"
+
+  bgp {
+    asn = "64514"
+  }
+
+  region  = "us-central1"
+  project = "${var.project_id}"
+}
+
+data "google_compute_subnetwork" "main" {
+  name    = "default"
+  project = "${var.project_id}"
+  region  = "${google_compute_router.main.region}"
+}
+
+resource "google_compute_router_nat" "main" {
+  name                               = "${random_pet.main.id}"
+  router                             = "${google_compute_router.main.name}"
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+
+  subnetwork {
+    name                    = "${data.google_compute_subnetwork.main.self_link}"
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+
+  project = "${var.project_id}"
+  region  = "${google_compute_router.main.region}"
+}

--- a/examples/real_time_enforcer/outputs.tf
+++ b/examples/real_time_enforcer/outputs.tf
@@ -33,11 +33,6 @@ output "forseti-rt-enforcer-vm-ip" {
   value       = "${module.real_time_enforcer.forseti-rt-enforcer-vm-ip}"
 }
 
-output "forseti-rt-enforcer-vm-public-ip" {
-  description = "Forseti Enforcer VM public IP address"
-  value       = "${module.real_time_enforcer.forseti-rt-enforcer-vm-public-ip}"
-}
-
 output "forseti-rt-enforcer-service-account" {
   description = "Forseti Enforcer service account"
   value       = "${module.real_time_enforcer.forseti-rt-enforcer-service-account}"

--- a/modules/real_time_enforcer/outputs.tf
+++ b/modules/real_time_enforcer/outputs.tf
@@ -24,11 +24,6 @@ output "forseti-rt-enforcer-vm-ip" {
   value       = "${google_compute_instance.main.network_interface.0.network_ip}"
 }
 
-output "forseti-rt-enforcer-vm-public-ip" {
-  description = "Forseti Enforcer VM public IP address"
-  value       = "${google_compute_instance.main.network_interface.0.access_config.0.nat_ip}"
-}
-
 output "forseti-rt-enforcer-service-account" {
   description = "Forseti Enforcer service account"
   value       = "${google_service_account.main.email}"

--- a/modules/real_time_enforcer/variables.tf
+++ b/modules/real_time_enforcer/variables.tf
@@ -80,6 +80,17 @@ variable "enforcer_instance_metadata" {
   default     = {}
 }
 
+variable "enforcer_instance_access_config" {
+  description = "Enforcer instance 'access_config' block"
+  type        = "map"
+  default     = {}
+}
+
+variable "enforcer_instance_private" {
+  description = "Enable enforcer instance private IP"
+  default     = "true"
+}
+
 variable "suffix" {
   description = "The random suffix to append to all Forseti resources"
 }

--- a/test/fixtures/real_time_enforcer/main.tf
+++ b/test/fixtures/real_time_enforcer/main.tf
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+provider "tls" {
+  version = "~> 1.2"
+}
+
 resource "tls_private_key" "main" {
   algorithm = "RSA"
   rsa_bits  = 4096
@@ -22,6 +26,15 @@ resource "tls_private_key" "main" {
 resource "local_file" "gce-keypair-pk" {
   content  = "${tls_private_key.main.private_key_pem}"
   filename = "${path.module}/sshkey"
+}
+
+module "bastion" {
+  source = "../bastion"
+
+  network    = "default"
+  project_id = "${var.project_id}"
+  subnetwork = "default"
+  zone       = "us-central1-f"
 }
 
 module "real_time_enforcer" {

--- a/test/fixtures/real_time_enforcer/outputs.tf
+++ b/test/fixtures/real_time_enforcer/outputs.tf
@@ -48,11 +48,6 @@ output "forseti-rt-enforcer-vm-ip" {
   value       = "${module.real_time_enforcer.forseti-rt-enforcer-vm-ip}"
 }
 
-output "forseti-rt-enforcer-vm-public-ip" {
-  description = "Forseti Enforcer VM public IP address"
-  value       = "${module.real_time_enforcer.forseti-rt-enforcer-vm-public-ip}"
-}
-
 output "forseti-rt-enforcer-service-account" {
   description = "Forseti Enforcer service account"
   value       = "${module.real_time_enforcer.forseti-rt-enforcer-service-account}"

--- a/test/fixtures/real_time_enforcer/outputs.tf
+++ b/test/fixtures/real_time_enforcer/outputs.tf
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+output "bastion_host" {
+  value       = "${module.bastion.host}"
+  description = "Bastion host"
+}
+
 output "project_id" {
   description = "A forwarded copy of `project_id` for InSpec"
   value       = "${var.project_id}"


### PR DESCRIPTION
This adds capability to have a private Forseti enforcer VM and makes it the default.