### PR TITLE
Output CloudSQL Connection String

### DIFF
--- a/modules/server/outputs.tf
+++ b/modules/server/outputs.tf
@@ -33,3 +33,8 @@ output "forseti-server-storage-bucket" {
   description = "Forseti Server storage bucket"
   value       = "${google_storage_bucket.server_config.id}"
 }
+
+output "forseti-cloudsql-connection-name" {
+  description = "The connection string to the CloudSQL instance"
+  value       = "${google_sql_database_instance.master.connection_name}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -54,6 +54,11 @@ output "forseti-server-storage-bucket" {
   value       = "${module.server.forseti-server-storage-bucket}"
 }
 
+output "forseti-cloudsql-connection-name" {
+  description = "Forseti CloudSQL Connection String"
+  value = "${module.server.forseti-cloudsql-connection-name}"
+}
+
 output "suffix" {
   description = "The random suffix appended to Forseti resources"
   value       = "${local.random_hash}"


### PR DESCRIPTION
Having the CloudSQL connection string as an output is useful information for components such as a cloudsql proxy.