### PR TITLE
Update main.tf

### DIFF
--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -459,6 +459,11 @@ resource "google_sql_database_instance" "master" {
     }
   }
 
+  lifecycle {
+    ignore_changes = [
+      "settings.0.disk_size",
+    ]
+  }
   depends_on = ["null_resource.services-dependency"]
 }
 


### PR DESCRIPTION
Addresses [issue 153](https://github.com/forseti-security/terraform-google-forseti/issues/153) 
The Cloud SQL resource is (correctly) defined with `settings.0.disk_autoresize:"true"`, so ignoring changes to `settings.0.disk_size` prevents issues with later reruns of terraform.