### PR TITLE
Drop requirement for an exported service account key

### DIFF
--- a/examples/real_time_enforcer/README.md
+++ b/examples/real_time_enforcer/README.md
@@ -2,6 +2,8 @@
 
 This example illustrates how to set up a Forseti installation with real-time policy enforcer.
 
+By default, terraform will use your application default credentials.  If you'd like to use a different service account key, set the environment variable `GOOGLE_APPLICATION_CREDENTIALS` to the desired key's path.  For more info on using the GCP provider, refer to the terraform documentation.
+
 [^]: (autogen_docs_start)
 
 ## Inputs

--- a/examples/real_time_enforcer/main.tf
+++ b/examples/real_time_enforcer/main.tf
@@ -15,7 +15,6 @@
  */
 
 provider "google" {
-  credentials = "${file(var.credentials_path)}"
   version     = "~> 1.20"
 }
 

--- a/examples/real_time_enforcer/variables.tf
+++ b/examples/real_time_enforcer/variables.tf
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-variable "credentials_path" {
-  description = "Path to service account json"
-}
-
 variable "project_id" {
   description = "The ID of an existing Google project where Forseti will be installed"
 }

--- a/test/README.md
+++ b/test/README.md
@@ -17,7 +17,6 @@ cp test/fixtures/shared/terraform.tfvars.example test/fixtures/shared_vpc/terraf
 Update `terraform.tfvars` to match your environment:
 
 ```
-credentials_path = "/path/to/credentials.json"
 network_project = "sample-project-001"
 project_id = "service-project-001"
 org_id = 100000000000
@@ -31,6 +30,9 @@ subnetwork = "subnet-001"
 From the root of the module directory execute the following commands:
 
 ```
+# if necessary, point terraform to service account key
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/credentials.json"
+
 # Initialize the terraform providers and context
 bundle exec kitchen setup shared-vpc
 
@@ -63,7 +65,6 @@ cp test/fixtures/simple_example/terraform.tfvars.example test/fixtures/simple_ex
 Update `terraform.tfvars` to match your environment:
 
 ```bash
-credentials_path = "../../../credentials.json"`
 gsuite_admin_email = "admin@example.com"
 org_id = "000000000000"
 project_id = "forseti-test-f6bd"
@@ -74,6 +75,9 @@ project_id = "forseti-test-f6bd"
 From the root of the module directory execute the following commands:
 
 ```bash
+# if necessary, point terraform to service account key
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/credentials.json"
+
 # Initialize the terraform providers and context
 bundle exec kitchen setup simple-example
 

--- a/test/fixtures/real_time_enforcer/main.tf
+++ b/test/fixtures/real_time_enforcer/main.tf
@@ -40,7 +40,6 @@ module "bastion" {
 module "real_time_enforcer" {
   source = "../../../examples/real_time_enforcer"
 
-  credentials_path    = "${var.credentials_path}"
   project_id          = "${var.project_id}"
   org_id              = "${var.org_id}"
   enforcer_project_id = "${var.enforcer_project_id}"

--- a/test/fixtures/real_time_enforcer/variables.tf
+++ b/test/fixtures/real_time_enforcer/variables.tf
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-variable "credentials_path" {
-  description = "Path to service account json"
-}
-
 variable "project_id" {
   description = "The ID of an existing Google project where Forseti will be installed"
 }

--- a/test/fixtures/real_time_enforcer_roles/main.tf
+++ b/test/fixtures/real_time_enforcer_roles/main.tf
@@ -15,7 +15,6 @@
  */
 
 provider "google" {
-  credentials = "${file(var.credentials_path)}"
   version     = "~> 1.20"
 }
 

--- a/test/fixtures/real_time_enforcer_roles/variables.tf
+++ b/test/fixtures/real_time_enforcer_roles/variables.tf
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-variable "credentials_path" {
-  description = "Path to service account json"
-}
-
 variable "org_id" {
   description = "The organization ID where the IAM roles will be created."
 }


### PR DESCRIPTION
This will allow the user to use any SDK supported credential for terraform.