### PR TITLE
Adding parameter to google_sql_user resource

### DIFF
--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -521,6 +521,7 @@ resource "google_sql_user" "root" {
   name     = "root"
   instance = google_sql_database_instance.master.name
   project  = var.project_id
+  host     = var.cloudsql_user_host
 }
 
 resource "null_resource" "services-dependency" {

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -610,6 +610,11 @@ variable "cloudsql_type" {
   default     = "db-n1-standard-1"
 }
 
+variable "cloudsql_user_host" {
+  description = "The host the user can connect from.  Can be an IP address or IP address range. Changing this forces a new resource to be created."
+  default     = "%"
+}
+
 #----------------#
 # Forseti bucket #
 #----------------#

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -611,7 +611,7 @@ variable "cloudsql_type" {
 }
 
 variable "cloudsql_user_host" {
-  description = "The host the user can connect from.  Can be an IP address or IP address range. Changing this forces a new resource to be created."
+  description = "The host the user can connect from. Can be an IP address or IP address range. Changing this forces a new resource to be created."
   default     = "%"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -697,6 +697,11 @@ variable "cloudsql_type" {
   default     = "db-n1-standard-1"
 }
 
+variable "cloudsql_user_host" {
+  description = "The host the user can connect from.  Can be an IP address or IP address range. Changing this forces a new resource to be created."
+  default     = "%"
+}
+
 #----------------#
 # Forseti bucket #
 #----------------#


### PR DESCRIPTION
Signed-off-by: Ken Evensen <kdevensen@google.com>

This helps address issue #148.  By specifying the host parameter, the requirements for the parameter being present on destruction are satisfied.

This appears to be the default behavior intended by the documentation: https://cloud.google.com/sql/docs/mysql/create-manage-users.