### PR TITLE
Remove roles/bigquery.dataViewer role from server

### DIFF
--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -62,7 +62,6 @@ locals {
   ]
   server_read_roles = [
     "roles/appengine.appViewer",
-    "roles/bigquery.dataViewer",
     "roles/bigquery.metadataViewer",
     "roles/browser",
     "roles/cloudasset.viewer",


### PR DESCRIPTION
It is sufficient for the forseti server to have roles/bigquery.metadataViewer to view bigquery resources; it does not need roles/bigquery.dataViewer.

We can see the forseti python installer does not have this role: 
https://github.com/forseti-security/forseti-security/blob/886e4bdc42ce7220f65f7babffd1faeaedae4e6a/install/gcp/installer/util/constants.py#L88

It was removed in https://github.com/forseti-security/forseti-security/pull/2395.