### PR TITLE
Support for Policy Library Sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Simple usage of the module within your own main.tf file is as follows:
 | policy\_library\_home | The local policy library directory | string | `"$USER_HOME/policy-library"` | no |
 | policy\_library\_repository\_url | The git repository containing the policy-library. | string | `""` | no |
 | policy\_library\_sync\_enabled | Sync config validator policy library from private repository | string | `"false"` | no |
+| policy\_library\_sync\_gcs\_directory\_name | The directory name of the GCS folder used for the policy library sync config | string | `"policy_library_sync"` | no |
 | policy\_library\_sync\_git\_sync\_tag | Tag for the git-sync image | string | `"v3.1.2"` | no |
 | policy\_library\_sync\_ssh\_known\_hosts | List of authorized public keys for SSH host of the policy library repository| string | `""` | no |
 | project\_id | Google Project ID that you want Forseti deployed into | string | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -147,6 +147,11 @@ Simple usage of the module within your own main.tf file is as follows:
 | network | The VPC where the Forseti client and server will be created | string | `"default"` | no |
 | network\_project | The project containing the VPC and subnetwork where the Forseti client and server will be created | string | `""` | no |
 | org\_id | GCP Organization ID that Forseti will have purview over | string | `""` | no |
+| policy\_library\_home | The local policy library directory | string | `"$USER_HOME/policy-library"` | no |
+| policy\_library\_repository\_url | The git repository containing the policy-library. | string | `""` | no |
+| policy\_library\_sync\_enabled | Sync config validator policy library from private repository | string | `"false"` | no |
+| policy\_library\_sync\_git\_sync\_tag | Tag for the git-sync image | string | `"v3.1.2"` | no |
+| policy\_library\_sync\_ssh\_known\_hosts | List of authorized public keys for SSH host of the policy library repository| string | `""` | no |
 | project\_id | Google Project ID that you want Forseti deployed into | string | n/a | yes |
 | resource\_enabled | Resource scanner enabled. | string | `"true"` | no |
 | resource\_violations\_should\_notify | Notify for resource violations | string | `"true"` | no |
@@ -187,6 +192,7 @@ Simple usage of the module within your own main.tf file is as follows:
 | forseti-client-vm-ip | Forseti Client VM private IP address |
 | forseti-client-vm-name | Forseti Client VM name |
 | forseti-cloudsql-connection-name | Forseti CloudSQL Connection String |
+| forseti-server-git-public-key-openssh | The public OpenSSH key generated to allow the Forseti Server to clone the policy library repository |
 | forseti-server-service-account | Forseti Server service account |
 | forseti-server-storage-bucket | Forseti Server storage bucket |
 | forseti-server-vm-ip | Forseti Server VM private IP address |

--- a/main.tf
+++ b/main.tf
@@ -247,6 +247,7 @@ module "server" {
   policy_library_home                                 = var.policy_library_home
   policy_library_repository_url                       = var.policy_library_repository_url
   policy_library_sync_enabled                         = var.policy_library_sync_enabled
+  policy_library_sync_gcs_directory_name              = var.policy_library_sync_gcs_directory_name
   policy_library_sync_git_sync_tag                    = var.policy_library_sync_git_sync_tag
   policy_library_sync_ssh_known_hosts                 = var.policy_library_sync_ssh_known_hosts
 

--- a/main.tf
+++ b/main.tf
@@ -244,6 +244,11 @@ module "server" {
   violations_slack_webhook                            = var.violations_slack_webhook
   cscc_violations_enabled                             = var.cscc_violations_enabled
   cscc_source_id                                      = var.cscc_source_id
+  policy_library_home                                 = var.policy_library_home
+  policy_library_repository_url                       = var.policy_library_repository_url
+  policy_library_sync_enabled                         = var.policy_library_sync_enabled
+  policy_library_sync_git_sync_tag                    = var.policy_library_sync_git_sync_tag
+  policy_library_sync_ssh_known_hosts                 = var.policy_library_sync_ssh_known_hosts
 
   groups_settings_max_calls                = var.groups_settings_max_calls
   groups_settings_period                   = var.groups_settings_period

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -92,8 +92,9 @@ locals {
     }],
 
   }
-  network_interface = local.network_interface_base[var.server_private ? "private" : "public"]
-  missing_emails    = ((var.sendgrid_api_key != "") && (var.forseti_email_sender == "" || var.forseti_email_recipient == "") ? 1 : 0)
+  network_interface                         = local.network_interface_base[var.server_private ? "private" : "public"]
+  missing_emails                            = ((var.sendgrid_api_key != "") && (var.forseti_email_sender == "" || var.forseti_email_recipient == "") ? 1 : 0)
+  policy_library_sync_folder                = "policy_library_sync"
 }
 
 #------------------#
@@ -114,16 +115,18 @@ data "template_file" "forseti_server_startup_script" {
   template = local.server_startup_script
 
   vars = {
-    forseti_environment          = data.template_file.forseti_server_environment.rendered
-    forseti_env                  = data.template_file.forseti_server_env.rendered
-    forseti_run_frequency        = var.forseti_run_frequency
-    forseti_repo_url             = var.forseti_repo_url
-    forseti_version              = var.forseti_version
-    forseti_server_conf_path     = local.server_conf_path
-    forseti_home                 = var.forseti_home
-    cloudsql_proxy_arch          = var.cloudsql_proxy_arch
-    storage_bucket_name          = local.server_bucket_name
-    forseti_conf_server_checksum = base64sha256(data.template_file.forseti_server_config.rendered)
+    cloudsql_proxy_arch                       = var.cloudsql_proxy_arch
+    forseti_conf_server_checksum              = base64sha256(data.template_file.forseti_server_config.rendered)
+    forseti_env                               = data.template_file.forseti_server_env.rendered
+    forseti_environment                       = data.template_file.forseti_server_environment.rendered
+    forseti_home                              = var.forseti_home
+    forseti_repo_url                          = var.forseti_repo_url
+    forseti_run_frequency                     = var.forseti_run_frequency
+    forseti_server_conf_path                  = local.server_conf_path
+    forseti_version                           = var.forseti_version
+    policy_library_home                       = var.policy_library_home
+    policy_library_sync_enabled               = var.policy_library_sync_enabled
+    storage_bucket_name                       = local.server_bucket_name
   }
 }
 
@@ -131,9 +134,13 @@ data "template_file" "forseti_server_environment" {
   template = local.server_environment
 
   vars = {
-    forseti_home             = var.forseti_home
-    forseti_server_conf_path = local.server_conf_path
-    storage_bucket_name      = local.server_bucket_name
+    forseti_home                      = var.forseti_home
+    forseti_server_conf_path          = local.server_conf_path
+    policy_library_home               = var.policy_library_home
+    policy_library_sync_enabled       = var.policy_library_sync_enabled
+    policy_library_repository_url     = var.policy_library_repository_url
+    policy_library_sync_git_sync_tag  = var.policy_library_sync_git_sync_tag
+    storage_bucket_name               = local.server_bucket_name
   }
 }
 
@@ -425,6 +432,32 @@ resource "google_storage_bucket" "cai_export" {
   depends_on = [null_resource.services-dependency]
 }
 
+resource "tls_private_key" "policy_library_sync_ssh" {
+  count       = "${var.policy_library_sync_enabled ? 1 : 0}"
+  algorithm   = "RSA"
+}
+
+resource "google_storage_bucket_object" "policy_library_sync_ssh_key" {
+  count   = var.policy_library_sync_enabled && var.policy_library_repository_url != "" ? 1 : 0
+  name    = "${local.policy_library_sync_folder}/ssh"
+  content = tls_private_key.policy_library_sync_ssh[0].private_key_pem
+  bucket  = local.server_bucket_name
+
+  depends_on = [
+    google_storage_bucket.server_config,
+    tls_private_key.policy_library_sync_ssh,
+  ]
+}
+
+resource "google_storage_bucket_object" "policy_library_sync_ssh_known_hosts" {
+  count   = var.policy_library_sync_enabled && var.policy_library_sync_ssh_known_hosts != "" ? 1 : 0
+  name    = "${local.policy_library_sync_folder}/known_hosts"
+  content = var.policy_library_sync_ssh_known_hosts
+  bucket  = local.server_bucket_name
+
+  depends_on = [google_storage_bucket.server_config]
+}
+
 #-------------------------#
 # Forseti server instance #
 #-------------------------#
@@ -437,6 +470,7 @@ resource "google_compute_instance" "forseti-server" {
   allow_stopping_for_update = true
   metadata                  = var.server_instance_metadata
   metadata_startup_script   = data.template_file.forseti_server_startup_script.rendered
+
   dynamic "network_interface" {
     for_each = local.network_interface
     content {
@@ -479,16 +513,16 @@ resource "google_compute_instance" "forseti-server" {
   }
 
   depends_on = [
-    google_service_account.forseti_server,
-    module.server_rules,
-    null_resource.services-dependency,
-    google_project_iam_member.server_roles,
-    google_organization_iam_member.org_read,
     google_folder_iam_member.folder_read,
-    google_organization_iam_member.org_write,
     google_folder_iam_member.folder_write,
     google_organization_iam_member.org_cscc,
-
+    google_organization_iam_member.org_read,
+    google_organization_iam_member.org_write,
+    google_project_iam_member.server_roles,
+    google_service_account.forseti_server,
+    google_storage_bucket.server_config,
+    module.server_rules,
+    null_resource.services-dependency,
   ]
 }
 
@@ -539,4 +573,3 @@ resource "null_resource" "services-dependency" {
     services = jsonencode(var.services)
   }
 }
-

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -433,7 +433,7 @@ resource "google_storage_bucket" "cai_export" {
 }
 
 resource "tls_private_key" "policy_library_sync_ssh" {
-  count     = "${var.policy_library_sync_enabled ? 1 : 0}"
+  count     = var.policy_library_sync_enabled ? 1 : 0
   algorithm = "RSA"
 }
 

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -92,9 +92,9 @@ locals {
     }],
 
   }
-  network_interface                         = local.network_interface_base[var.server_private ? "private" : "public"]
-  missing_emails                            = ((var.sendgrid_api_key != "") && (var.forseti_email_sender == "" || var.forseti_email_recipient == "") ? 1 : 0)
-  policy_library_sync_folder                = "policy_library_sync"
+  missing_emails             = ((var.sendgrid_api_key != "") && (var.forseti_email_sender == "" || var.forseti_email_recipient == "") ? 1 : 0)
+  network_interface          = local.network_interface_base[var.server_private ? "private" : "public"]
+  policy_library_sync_folder = "policy_library_sync"
 }
 
 #------------------#
@@ -115,18 +115,18 @@ data "template_file" "forseti_server_startup_script" {
   template = local.server_startup_script
 
   vars = {
-    cloudsql_proxy_arch                       = var.cloudsql_proxy_arch
-    forseti_conf_server_checksum              = base64sha256(data.template_file.forseti_server_config.rendered)
-    forseti_env                               = data.template_file.forseti_server_env.rendered
-    forseti_environment                       = data.template_file.forseti_server_environment.rendered
-    forseti_home                              = var.forseti_home
-    forseti_repo_url                          = var.forseti_repo_url
-    forseti_run_frequency                     = var.forseti_run_frequency
-    forseti_server_conf_path                  = local.server_conf_path
-    forseti_version                           = var.forseti_version
-    policy_library_home                       = var.policy_library_home
-    policy_library_sync_enabled               = var.policy_library_sync_enabled
-    storage_bucket_name                       = local.server_bucket_name
+    cloudsql_proxy_arch          = var.cloudsql_proxy_arch
+    forseti_conf_server_checksum = base64sha256(data.template_file.forseti_server_config.rendered)
+    forseti_env                  = data.template_file.forseti_server_env.rendered
+    forseti_environment          = data.template_file.forseti_server_environment.rendered
+    forseti_home                 = var.forseti_home
+    forseti_repo_url             = var.forseti_repo_url
+    forseti_run_frequency        = var.forseti_run_frequency
+    forseti_server_conf_path     = local.server_conf_path
+    forseti_version              = var.forseti_version
+    policy_library_home          = var.policy_library_home
+    policy_library_sync_enabled  = var.policy_library_sync_enabled
+    storage_bucket_name          = local.server_bucket_name
   }
 }
 
@@ -134,13 +134,13 @@ data "template_file" "forseti_server_environment" {
   template = local.server_environment
 
   vars = {
-    forseti_home                      = var.forseti_home
-    forseti_server_conf_path          = local.server_conf_path
-    policy_library_home               = var.policy_library_home
-    policy_library_sync_enabled       = var.policy_library_sync_enabled
-    policy_library_repository_url     = var.policy_library_repository_url
-    policy_library_sync_git_sync_tag  = var.policy_library_sync_git_sync_tag
-    storage_bucket_name               = local.server_bucket_name
+    forseti_home                     = var.forseti_home
+    forseti_server_conf_path         = local.server_conf_path
+    policy_library_home              = var.policy_library_home
+    policy_library_sync_enabled      = var.policy_library_sync_enabled
+    policy_library_repository_url    = var.policy_library_repository_url
+    policy_library_sync_git_sync_tag = var.policy_library_sync_git_sync_tag
+    storage_bucket_name              = local.server_bucket_name
   }
 }
 
@@ -433,8 +433,8 @@ resource "google_storage_bucket" "cai_export" {
 }
 
 resource "tls_private_key" "policy_library_sync_ssh" {
-  count       = "${var.policy_library_sync_enabled ? 1 : 0}"
-  algorithm   = "RSA"
+  count     = "${var.policy_library_sync_enabled ? 1 : 0}"
+  algorithm = "RSA"
 }
 
 resource "google_storage_bucket_object" "policy_library_sync_ssh_key" {

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -92,9 +92,8 @@ locals {
     }],
 
   }
-  missing_emails             = ((var.sendgrid_api_key != "") && (var.forseti_email_sender == "" || var.forseti_email_recipient == "") ? 1 : 0)
-  network_interface          = local.network_interface_base[var.server_private ? "private" : "public"]
-  policy_library_sync_folder = "policy_library_sync"
+  missing_emails    = ((var.sendgrid_api_key != "") && (var.forseti_email_sender == "" || var.forseti_email_recipient == "") ? 1 : 0)
+  network_interface = local.network_interface_base[var.server_private ? "private" : "public"]
 }
 
 #------------------#
@@ -115,18 +114,19 @@ data "template_file" "forseti_server_startup_script" {
   template = local.server_startup_script
 
   vars = {
-    cloudsql_proxy_arch          = var.cloudsql_proxy_arch
-    forseti_conf_server_checksum = base64sha256(data.template_file.forseti_server_config.rendered)
-    forseti_env                  = data.template_file.forseti_server_env.rendered
-    forseti_environment          = data.template_file.forseti_server_environment.rendered
-    forseti_home                 = var.forseti_home
-    forseti_repo_url             = var.forseti_repo_url
-    forseti_run_frequency        = var.forseti_run_frequency
-    forseti_server_conf_path     = local.server_conf_path
-    forseti_version              = var.forseti_version
-    policy_library_home          = var.policy_library_home
-    policy_library_sync_enabled  = var.policy_library_sync_enabled
-    storage_bucket_name          = local.server_bucket_name
+    cloudsql_proxy_arch                    = var.cloudsql_proxy_arch
+    forseti_conf_server_checksum           = base64sha256(data.template_file.forseti_server_config.rendered)
+    forseti_env                            = data.template_file.forseti_server_env.rendered
+    forseti_environment                    = data.template_file.forseti_server_environment.rendered
+    forseti_home                           = var.forseti_home
+    forseti_repo_url                       = var.forseti_repo_url
+    forseti_run_frequency                  = var.forseti_run_frequency
+    forseti_server_conf_path               = local.server_conf_path
+    forseti_version                        = var.forseti_version
+    policy_library_home                    = var.policy_library_home
+    policy_library_sync_enabled            = var.policy_library_sync_enabled
+    policy_library_sync_gcs_directory_name = var.policy_library_sync_gcs_directory_name
+    storage_bucket_name                    = local.server_bucket_name
   }
 }
 
@@ -439,7 +439,7 @@ resource "tls_private_key" "policy_library_sync_ssh" {
 
 resource "google_storage_bucket_object" "policy_library_sync_ssh_key" {
   count   = var.policy_library_sync_enabled && var.policy_library_repository_url != "" ? 1 : 0
-  name    = "${local.policy_library_sync_folder}/ssh"
+  name    = "${var.policy_library_sync_gcs_directory_name}/ssh"
   content = tls_private_key.policy_library_sync_ssh[0].private_key_pem
   bucket  = local.server_bucket_name
 
@@ -451,7 +451,7 @@ resource "google_storage_bucket_object" "policy_library_sync_ssh_key" {
 
 resource "google_storage_bucket_object" "policy_library_sync_ssh_known_hosts" {
   count   = var.policy_library_sync_enabled && var.policy_library_sync_ssh_known_hosts != "" ? 1 : 0
-  name    = "${local.policy_library_sync_folder}/known_hosts"
+  name    = "${var.policy_library_sync_gcs_directory_name}/known_hosts"
   content = var.policy_library_sync_ssh_known_hosts
   bucket  = local.server_bucket_name
 

--- a/modules/server/outputs.tf
+++ b/modules/server/outputs.tf
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-output "forseti-server-vm-name" {
-  description = "Forseti Server VM name"
-  value       = google_compute_instance.forseti-server.name
+output "forseti-cloudsql-connection-name" {
+  description = "The connection string to the CloudSQL instance"
+  value       = google_sql_database_instance.master.connection_name
 }
 
-output "forseti-server-vm-ip" {
-  description = "Forseti Server VM private IP address"
-  value       = google_compute_instance.forseti-server.network_interface[0].network_ip
+output "forseti-server-git-public-key-openssh" {
+  description = "The public OpenSSH key generated to allow the Forseti Server to clone the policy library repository."
+  value       = tls_private_key.policy_library_sync_ssh[0].public_key_openssh
 }
 
 output "forseti-server-service-account" {
@@ -34,8 +34,12 @@ output "forseti-server-storage-bucket" {
   value       = google_storage_bucket.server_config.id
 }
 
-output "forseti-cloudsql-connection-name" {
-  description = "The connection string to the CloudSQL instance"
-  value       = google_sql_database_instance.master.connection_name
+output "forseti-server-vm-ip" {
+  description = "Forseti Server VM private IP address"
+  value       = google_compute_instance.forseti-server.network_interface[0].network_ip
 }
 
+output "forseti-server-vm-name" {
+  description = "Forseti Server VM name"
+  value       = google_compute_instance.forseti-server.name
+}

--- a/modules/server/templates/scripts/forseti-server/forseti_environment.sh.tpl
+++ b/modules/server/templates/scripts/forseti-server/forseti_environment.sh.tpl
@@ -1,3 +1,7 @@
 export FORSETI_HOME=${forseti_home}
 export FORSETI_SERVER_CONF=${forseti_server_conf_path}
+export POLICY_LIBRARY_HOME=${policy_library_home}
+export POLICY_LIBRARY_SYNC_ENABLED=${policy_library_sync_enabled}
+export POLICY_LIBRARY_SYNC_GIT_SYNC_TAG=${policy_library_sync_git_sync_tag}
+export POLICY_LIBRARY_REPOSITORY_URL=${policy_library_repository_url}
 export SCANNER_BUCKET=${storage_bucket_name}

--- a/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
+++ b/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
@@ -76,18 +76,47 @@ echo "${forseti_environment}" > /etc/profile.d/forseti_environment.sh | sudo sh
 gsutil cp gs://${storage_bucket_name}/configs/forseti_conf_server.yaml ${forseti_server_conf_path}
 gsutil cp -r gs://${storage_bucket_name}/rules ${forseti_home}/
 
-# Download the Newest Config Validator constraints from GCS
-rm -rf ${forseti_home}/policy-library
+# Get Config Validator constraints
+sudo mkdir -m 777 -p ${policy_library_home}
+if [ "${policy_library_sync_enabled}" == "true" ]; then
+  # Policy Library Sync
+  echo "Forseti Startup - Policy Library sync is enabled."
 
-# Attempt to download the config-validator policy and gracefully handle the absence
-# of policy files.  The config-validator is not required for the rest of Forseti
-# and should not halt installation.
-gsutil cp -r gs://${storage_bucket_name}/policy-library ${forseti_home}/ || echo "No policy available, continuing with Forseti installation"
+  # Install Docker
+  if [ -z "$(which docker)" ]; then
+    echo "Forseti Startup - Installing Docker."
+    sudo apt-get update
+    sudo apt -y install apt-transport-https ca-certificates curl software-properties-common
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+    sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable"
+    sudo apt update
+    apt-cache policy docker-ce
+    sudo apt install -y docker-ce
+  fi
+
+  # Setup local FS
+  # Note: gsutil is using the -n flag so that once the SSH key is copied locally, it is not overwritten for any subsequent runs of terraform
+  sudo mkdir -p /etc/git-secret
+  sudo gsutil cp -n gs://${storage_bucket_name}/policy_library_sync/* /etc/git-secret/
+else
+  # DEPRECATED! Remove once users have migrated over to Git-Sync
+  # Download the Newest Config Validator constraints from GCS
+  echo "Forseti Startup - Copying Policy Library from GCS."
+
+  # Attempt to download the config-validator policy and gracefully handle the absence
+  # of policy files.  The config-validator is not required for the rest of Forseti
+  # and should not halt installation.
+  gsutil cp -r gs://${storage_bucket_name}/policy-library ${policy_library_home}/ || echo "No policy available, continuing with Forseti installation"
+fi
 
 # Start Forseti service depends on vars defined above.
 bash ./install/gcp/scripts/initialize_forseti_services.sh
 echo "Starting services."
 systemctl start cloudsqlproxy
+if [ "${policy_library_sync_enabled}" == "true" ]; then
+  systemctl start policy-library-sync
+  sleep 5
+fi
 systemctl start config-validator
 sleep 5
 

--- a/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
+++ b/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
@@ -97,7 +97,7 @@ if [ "${policy_library_sync_enabled}" == "true" ]; then
   # Setup local FS
   # Note: gsutil is using the -n flag so that once the SSH key is copied locally, it is not overwritten for any subsequent runs of terraform
   sudo mkdir -p /etc/git-secret
-  sudo gsutil cp -n gs://${storage_bucket_name}/policy_library_sync/* /etc/git-secret/
+  sudo gsutil cp -n gs://${storage_bucket_name}/${policy_library_sync_gcs_directory_name}/* /etc/git-secret/
 else
   # DEPRECATED! Remove once users have migrated over to Git-Sync
   # Download the Newest Config Validator constraints from GCS

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -387,12 +387,12 @@ variable "log_sink_enabled" {
 
 variable "policy_library_home" {
   description = "The local policy library directory."
-  default = "$USER_HOME/policy-library"
+  default     = "$USER_HOME/policy-library"
 }
 
 variable "policy_library_repository_url" {
   description = "The git repository containing the policy-library."
-  default = ""
+  default     = ""
 }
 
 variable "policy_library_sync_enabled" {
@@ -402,12 +402,12 @@ variable "policy_library_sync_enabled" {
 
 variable "policy_library_sync_git_sync_tag" {
   description = "Tag for the git-sync image."
-  default = "v3.1.2"
+  default     = "v3.1.2"
 }
 
 variable "policy_library_sync_ssh_known_hosts" {
   description = "List of authorized public keys for SSH host of the policy library repository."
-  default = ""
+  default     = ""
 }
 
 variable "resource_enabled" {

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -385,6 +385,31 @@ variable "log_sink_enabled" {
   default     = "true"
 }
 
+variable "policy_library_home" {
+  description = "The local policy library directory."
+  default = "$USER_HOME/policy-library"
+}
+
+variable "policy_library_repository_url" {
+  description = "The git repository containing the policy-library."
+  default = ""
+}
+
+variable "policy_library_sync_enabled" {
+  description = "Sync config validator policy library from private repository."
+  default     = "false"
+}
+
+variable "policy_library_sync_git_sync_tag" {
+  description = "Tag for the git-sync image."
+  default = "v3.1.2"
+}
+
+variable "policy_library_sync_ssh_known_hosts" {
+  description = "List of authorized public keys for SSH host of the policy library repository."
+  default = ""
+}
+
 variable "resource_enabled" {
   description = "Resource scanner enabled."
   default     = "true"
@@ -758,4 +783,3 @@ variable "groups_settings_violations_should_notify" {
   description = "Notify for groups settings violations"
   default     = "true"
 }
-

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -400,6 +400,11 @@ variable "policy_library_sync_enabled" {
   default     = "false"
 }
 
+variable "policy_library_sync_gcs_directory_name" {
+  description = "The directory name of the GCS folder used for the policy library sync config."
+  default     = "policy_library_sync"
+}
+
 variable "policy_library_sync_git_sync_tag" {
   description = "Tag for the git-sync image."
   default     = "v3.1.2"

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,31 +14,6 @@
  * limitations under the License.
  */
 
-output "forseti-server-vm-name" {
-  description = "Forseti Server VM name"
-  value       = module.server.forseti-server-vm-name
-}
-
-output "forseti-server-vm-ip" {
-  description = "Forseti Server VM private IP address"
-  value       = module.server.forseti-server-vm-ip
-}
-
-output "forseti-client-vm-name" {
-  description = "Forseti Client VM name"
-  value       = module.client.forseti-client-vm-name
-}
-
-output "forseti-client-vm-ip" {
-  description = "Forseti Client VM private IP address"
-  value       = module.client.forseti-client-vm-ip
-}
-
-output "forseti-server-service-account" {
-  description = "Forseti Server service account"
-  value       = module.server.forseti-server-service-account
-}
-
 output "forseti-client-service-account" {
   description = "Forseti Client service account"
   value       = module.client.forseti-client-service-account
@@ -49,18 +24,47 @@ output "forseti-client-storage-bucket" {
   value       = module.client.forseti-client-storage-bucket
 }
 
+output "forseti-cloudsql-connection-name" {
+  description = "Forseti CloudSQL Connection String"
+  value       = module.server.forseti-cloudsql-connection-name
+}
+
+output "forseti-client-vm-ip" {
+  description = "Forseti Client VM private IP address"
+  value       = module.client.forseti-client-vm-ip
+}
+
+output "forseti-client-vm-name" {
+  description = "Forseti Client VM name"
+  value       = module.client.forseti-client-vm-name
+}
+
+output "forseti-server-git-public-key-openssh" {
+  description = "The public OpenSSH key generated to allow the Forseti Server to clone the policy library repository."
+  value       = module.server.forseti-server-git-public-key-openssh
+}
+
 output "forseti-server-storage-bucket" {
   description = "Forseti Server storage bucket"
   value       = module.server.forseti-server-storage-bucket
 }
 
-output "forseti-cloudsql-connection-name" {
-  description = "Forseti CloudSQL Connection String"
-  value       = module.server.forseti-cloudsql-connection-name
+output "forseti-server-service-account" {
+  description = "Forseti Server service account"
+  value       = module.server.forseti-server-service-account
+}
+
+output "forseti-server-vm-ip" {
+  description = "Forseti Server VM private IP address"
+  value       = module.server.forseti-server-vm-ip
+}
+
+output "forseti-server-vm-name" {
+  description = "Forseti Server VM name"
+  value       = module.server.forseti-server-vm-name
 }
 
 output "suffix" {
   description = "The random suffix appended to Forseti resources"
   value       = local.random_hash
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -465,6 +465,11 @@ variable "policy_library_sync_enabled" {
   default     = "false"
 }
 
+variable "policy_library_sync_gcs_directory_name" {
+  description = "The directory name of the GCS folder used for the policy library sync config."
+  default     = "policy_library_sync"
+}
+
 variable "policy_library_sync_git_sync_tag" {
   description = "Tag for the git-sync image."
   default     = "v3.1.2"

--- a/variables.tf
+++ b/variables.tf
@@ -450,6 +450,31 @@ variable "log_sink_enabled" {
   default     = "true"
 }
 
+variable "policy_library_home" {
+  description = "The local policy library directory."
+  default = "$USER_HOME/policy-library"
+}
+
+variable "policy_library_repository_url" {
+  description = "The git repository containing the policy-library."
+  default = ""
+}
+
+variable "policy_library_sync_enabled" {
+  description = "Sync config validator policy library from private repository."
+  default     = "false"
+}
+
+variable "policy_library_sync_git_sync_tag" {
+  description = "Tag for the git-sync image."
+  default = "v3.1.2"
+}
+
+variable "policy_library_sync_ssh_known_hosts" {
+  description = "List of authorized public keys for SSH host of the policy library repository."
+  default = ""
+}
+
 variable "resource_enabled" {
   description = "Resource scanner enabled."
   default     = "true"

--- a/variables.tf
+++ b/variables.tf
@@ -452,12 +452,12 @@ variable "log_sink_enabled" {
 
 variable "policy_library_home" {
   description = "The local policy library directory."
-  default = "$USER_HOME/policy-library"
+  default     = "$USER_HOME/policy-library"
 }
 
 variable "policy_library_repository_url" {
   description = "The git repository containing the policy-library."
-  default = ""
+  default     = ""
 }
 
 variable "policy_library_sync_enabled" {
@@ -467,12 +467,12 @@ variable "policy_library_sync_enabled" {
 
 variable "policy_library_sync_git_sync_tag" {
   description = "Tag for the git-sync image."
-  default = "v3.1.2"
+  default     = "v3.1.2"
 }
 
 variable "policy_library_sync_ssh_known_hosts" {
   description = "List of authorized public keys for SSH host of the policy library repository."
-  default = ""
+  default     = ""
 }
 
 variable "resource_enabled" {


### PR DESCRIPTION
Updated core module and server module to support the policy library sync. If this option is enabled Terraform will: 1) create an SSH key and copy it to GCS and provide as output, 2) update the startup script to install docker and copy the private SSH key locally, in addition to providing some environment variables needed by Forseti to setup git-sync as a linux service.

Addresses #238.