### PR TITLE
Support import of existing Forseti installations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Extending the adopted spec, each change should have a link to its corresponding 
 
 - CloudSQL instance created in the same zone as GCE instances [#253]
 
+- Support for importing existing deployments created by the deprecated Python Installer. [#197]
+  - A variable to override the random resource name suffix
+  - A variable to toggle management of rules
+  - An import helper script
+
 ## [v4.1.0] - 2019-09-06
 
 ### Added
@@ -229,7 +234,7 @@ Version 4.0.0 is a backwards-incompatible release. Please see the [upgrade instr
 ### ADDED
 - This is the initial release of the Forseti module.
 
-[Unreleased]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v3.0.0...HEAD
+[Unreleased]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v4.0.1...HEAD
 [v0.1.0]: https://github.com/terraform-google-modules/terraform-google-forseti/releases/tag/v0.1.0
 [v1.0.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v0.1.0...v1.0.0
 [v1.1.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v1.0.0...v1.1.0
@@ -259,6 +264,7 @@ Version 4.0.0 is a backwards-incompatible release. Please see the [upgrade instr
 [#231]: https://github.com/forseti-security/terraform-google-forseti/pull/231
 [#225]: https://github.com/forseti-security/terraform-google-forseti/pull/225
 [#213]: https://github.com/forseti-security/terraform-google-forseti/pull/213
+[#197]: https://github.com/forseti-security/terraform-google-forseti/issues/197
 [#182]: https://github.com/forseti-security/terraform-google-forseti/pull/182
 [#211]: https://github.com/forseti-security/terraform-google-forseti/pull/211
 [#223]: https://github.com/forseti-security/terraform-google-forseti/pull/223

--- a/helpers/import.sh
+++ b/helpers/import.sh
@@ -87,6 +87,7 @@ while getopts ":hm:o:p:r:" opt; do
       ;;
     n )
       NETWORK_PROJECT_ID="$OPTARG"
+      ;;
     o )
       ORG_ID="$OPTARG"
       ;;

--- a/helpers/import.sh
+++ b/helpers/import.sh
@@ -163,8 +163,8 @@ terraform import "module.$MODULE_LOCAL_NAME.module.server.google_compute_firewal
 terraform import "module.$MODULE_LOCAL_NAME.module.server.google_storage_bucket.server_config" "$PROJECT_ID/forseti-server-$RESOURCE_NAME_SUFFIX"
 terraform import "module.$MODULE_LOCAL_NAME.module.server.google_storage_bucket.cai_export" "$PROJECT_ID/forseti-cai-export-$RESOURCE_NAME_SUFFIX"
 terraform import "module.$MODULE_LOCAL_NAME.module.server.google_compute_instance.forseti-server" "$PROJECT_ID/us-central1-c/forseti-server-vm-$RESOURCE_NAME_SUFFIX"
-terraform import "module.$MODULE_LOCAL_NAME.module.server.google_sql_database_instance.master" "$PROJECT_ID/forseti-server-db-$RESOURCE_NAME_SUFFIX"
-terraform import "module.$MODULE_LOCAL_NAME.module.server.google_sql_database.forseti-db" "$PROJECT_ID/forseti-server-db-$RESOURCE_NAME_SUFFIX/forseti_security"
-terraform import "module.$MODULE_LOCAL_NAME.module.server.google_sql_user.root" "$PROJECT_ID/forseti-server-db-$RESOURCE_NAME_SUFFIX/%/root"
+terraform import "module.$MODULE_LOCAL_NAME.module.cloudsql.google_sql_database_instance.master" "$PROJECT_ID/forseti-server-db-$RESOURCE_NAME_SUFFIX"
+terraform import "module.$MODULE_LOCAL_NAME.module.cloudsql.google_sql_database.forseti-db" "$PROJECT_ID/forseti-server-db-$RESOURCE_NAME_SUFFIX/forseti_security"
+terraform import "module.$MODULE_LOCAL_NAME.module.cloudsql.google_sql_user.root" "$PROJECT_ID/forseti-server-db-$RESOURCE_NAME_SUFFIX/%/root"
 
 printf "\n\nFinished import of Forseti resources to Terraform\n"

--- a/helpers/import.sh
+++ b/helpers/import.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+show_help() {
+  cat <<EOF
+Usage:
+
+    ${0##*/} -m MODULE_LOCAL_NAME -o ORG_ID -p PROJECT_ID -r RESOURCE_NAME_SUFFIX
+    ${0##*/} -h
+
+Import to Terraform a Forseti deployment created with the deprecated Python
+Installer. This script must be executed in the same directory as the target
+Terraform configuration.
+
+Required parameters:
+
+    -m MODULE_LOCAL_NAME    The local name given to the instance of the Forseti
+                            module in the Terraform configuration.
+    -o ORG_ID               The ID of the organization where Forseti is deployed.
+    -p PROJECT_ID           The ID of the project where Forseti is deployed.
+    -r RESOURCE_NAME_SUFFIX The suffix appended to the names of the Forseti
+                            resources; likely a 7 digit number.
+
+Example of usage:
+
+    ${0##*/} -m forseti -o 12345678901 -p forseti-235k -r 1234567
+
+Example of required Terraform configuration:
+
+    module "forseti" {
+      source = "terraform-google-modules/forseti/google"
+      version = "~> 4.1"
+
+      domain               = "DOMAIN"
+      project_id           = "PROJECT_ID"
+      resource_name_suffix = "RESOURCE_NAME_SUFFIX"
+      org_id               = "ORG_ID"
+
+      client_instance_metadata = {
+        enable-oslogin = "TRUE"
+      }
+      enable_write         = true
+      manage_rules_enabled = false
+    }
+
+EOF
+}
+
+if [[ ! $* =~ ^\-.+ ]]
+then
+  show_help
+  exit 0
+fi
+MODULE_LOCAL_NAME=""
+ORG_ID=""
+PROJECT_ID=""
+RESOURCE_NAME_SUFFIX=""
+while getopts ":hm:o:p:r:" opt; do
+  case ${opt} in
+    h )
+      show_help
+      exit 0
+      ;;
+    m )
+      MODULE_LOCAL_NAME="$OPTARG"
+      ;;
+    o )
+      ORG_ID="$OPTARG"
+      ;;
+    p )
+      PROJECT_ID="$OPTARG"
+      ;;
+    r )
+      RESOURCE_NAME_SUFFIX="$OPTARG"
+      ;;
+    \? )
+      echo "Invalid option: -$OPTARG; run ${0##*/} -h for more information" 1>&2
+      exit 1
+      ;;
+    : )
+      echo "Invalid option: -$OPTARG requires an argument; run ${0##*/} -h for more information" 1>&2
+      exit 1
+      ;;
+  esac
+done
+shift $((OPTIND -1))
+
+if [[ -z "$MODULE_LOCAL_NAME" ]]; then
+  echo "Missing required parameter: MODULE_LOCAL_NAME; run ${0##*/} -h for more information" 1>&2
+  exit 1
+fi
+
+if [[ -z "$PROJECT_ID" ]]; then
+  echo "Missing required parameter: PROJECT_ID; run ${0##*/} -h for more information" 1>&2
+  exit 1
+fi
+
+if [[ -z "$ORG_ID" ]]; then
+  echo "Missing required parameter: ORG_ID; run ${0##*/} -h for more information" 1>&2
+  exit 1
+fi
+
+if [[ -z "$RESOURCE_NAME_SUFFIX" ]]; then
+  echo "Missing required parameter: RESOURCE_NAME_SUFFIX; run ${0##*/} -h for more information" 1>&2
+  exit 1
+fi
+
+printf "\nStarting import of Forseti resources to Terraform\n\n"
+
+terraform import "module.$MODULE_LOCAL_NAME.google_project_service.main[0]" "$PROJECT_ID/admin.googleapis.com"
+terraform import "module.$MODULE_LOCAL_NAME.google_project_service.main[1]" "$PROJECT_ID/appengine.googleapis.com"
+terraform import "module.$MODULE_LOCAL_NAME.google_project_service.main[2]" "$PROJECT_ID/bigquery-json.googleapis.com"
+terraform import "module.$MODULE_LOCAL_NAME.google_project_service.main[3]" "$PROJECT_ID/cloudbilling.googleapis.com"
+terraform import "module.$MODULE_LOCAL_NAME.google_project_service.main[4]" "$PROJECT_ID/cloudresourcemanager.googleapis.com"
+terraform import "module.$MODULE_LOCAL_NAME.google_project_service.main[5]" "$PROJECT_ID/sql-component.googleapis.com"
+terraform import "module.$MODULE_LOCAL_NAME.google_project_service.main[6]" "$PROJECT_ID/sqladmin.googleapis.com"
+terraform import "module.$MODULE_LOCAL_NAME.google_project_service.main[7]" "$PROJECT_ID/compute.googleapis.com"
+terraform import "module.$MODULE_LOCAL_NAME.google_project_service.main[8]" "$PROJECT_ID/iam.googleapis.com"
+terraform import "module.$MODULE_LOCAL_NAME.google_project_service.main[9]" "$PROJECT_ID/cloudtrace.googleapis.com"
+terraform import "module.$MODULE_LOCAL_NAME.google_project_service.main[10]" "$PROJECT_ID/container.googleapis.com"
+terraform import "module.$MODULE_LOCAL_NAME.google_project_service.main[11]" "$PROJECT_ID/servicemanagement.googleapis.com"
+terraform import "module.$MODULE_LOCAL_NAME.google_project_service.main[12]" "$PROJECT_ID/logging.googleapis.com"
+terraform import "module.$MODULE_LOCAL_NAME.google_project_service.main[13]" "$PROJECT_ID/cloudasset.googleapis.com"
+terraform import "module.$MODULE_LOCAL_NAME.google_project_service.main[14]" "$PROJECT_ID/storage-api.googleapis.com"
+terraform import "module.$MODULE_LOCAL_NAME.google_project_service.main[15]" "$PROJECT_ID/groupssettings.googleapis.com"
+terraform import "module.$MODULE_LOCAL_NAME.module.client.google_compute_instance.forseti-client" "$PROJECT_ID/us-central1-c/forseti-client-vm-$RESOURCE_NAME_SUFFIX"
+terraform import "module.$MODULE_LOCAL_NAME.module.client.google_compute_firewall.forseti-client-deny-all" "$PROJECT_ID/forseti-client-deny-all-$RESOURCE_NAME_SUFFIX"
+terraform import "module.$MODULE_LOCAL_NAME.module.client.google_compute_firewall.forseti-client-ssh-external" "$PROJECT_ID/forseti-client-allow-ssh-external-$RESOURCE_NAME_SUFFIX"
+terraform import "module.$MODULE_LOCAL_NAME.module.client.google_project_iam_member.client_roles[0]" "$PROJECT_ID roles/storage.objectViewer serviceAccount:forseti-client-gcp-$RESOURCE_NAME_SUFFIX@$PROJECT_ID.iam.gserviceaccount.com"
+terraform import "module.$MODULE_LOCAL_NAME.module.client.google_service_account.forseti_client" "$PROJECT_ID/forseti-client-gcp-$RESOURCE_NAME_SUFFIX@$PROJECT_ID.iam.gserviceaccount.com"
+terraform import "module.$MODULE_LOCAL_NAME.module.client.google_storage_bucket.client_config" "$PROJECT_ID/forseti-client-$RESOURCE_NAME_SUFFIX"
+terraform import "module.$MODULE_LOCAL_NAME.module.server.google_service_account.forseti_server" "$PROJECT_ID/forseti-server-gcp-$RESOURCE_NAME_SUFFIX@$PROJECT_ID.iam.gserviceaccount.com"
+terraform import "module.$MODULE_LOCAL_NAME.module.server.google_project_iam_member.server_roles[0]" "$PROJECT_ID roles/storage.objectViewer serviceAccount:forseti-server-gcp-$RESOURCE_NAME_SUFFIX@$PROJECT_ID.iam.gserviceaccount.com"
+terraform import "module.$MODULE_LOCAL_NAME.module.server.google_project_iam_member.server_roles[1]" "$PROJECT_ID roles/storage.objectCreator serviceAccount:forseti-server-gcp-$RESOURCE_NAME_SUFFIX@$PROJECT_ID.iam.gserviceaccount.com"
+terraform import "module.$MODULE_LOCAL_NAME.module.server.google_project_iam_member.server_roles[2]" "$PROJECT_ID roles/cloudsql.client serviceAccount:forseti-server-gcp-$RESOURCE_NAME_SUFFIX@$PROJECT_ID.iam.gserviceaccount.com"
+terraform import "module.$MODULE_LOCAL_NAME.module.server.google_project_iam_member.server_roles[4]" "$PROJECT_ID roles/logging.logWriter serviceAccount:forseti-server-gcp-$RESOURCE_NAME_SUFFIX@$PROJECT_ID.iam.gserviceaccount.com"
+terraform import "module.$MODULE_LOCAL_NAME.module.server.google_organization_iam_member.org_read[0]" "$ORG_ID roles/appengine.appViewer serviceAccount:forseti-server-gcp-$RESOURCE_NAME_SUFFIX@$PROJECT_ID.iam.gserviceaccount.com"
+terraform import "module.$MODULE_LOCAL_NAME.module.server.google_organization_iam_member.org_read[1]" "$ORG_ID roles/bigquery.metadataViewer serviceAccount:forseti-server-gcp-$RESOURCE_NAME_SUFFIX@$PROJECT_ID.iam.gserviceaccount.com"
+terraform import "module.$MODULE_LOCAL_NAME.module.server.google_organization_iam_member.org_read[2]" "$ORG_ID roles/browser serviceAccount:forseti-server-gcp-$RESOURCE_NAME_SUFFIX@$PROJECT_ID.iam.gserviceaccount.com"
+terraform import "module.$MODULE_LOCAL_NAME.module.server.google_organization_iam_member.org_read[3]" "$ORG_ID roles/cloudasset.viewer serviceAccount:forseti-server-gcp-$RESOURCE_NAME_SUFFIX@$PROJECT_ID.iam.gserviceaccount.com"
+terraform import "module.$MODULE_LOCAL_NAME.module.server.google_organization_iam_member.org_read[4]" "$ORG_ID roles/cloudsql.viewer serviceAccount:forseti-server-gcp-$RESOURCE_NAME_SUFFIX@$PROJECT_ID.iam.gserviceaccount.com"
+terraform import "module.$MODULE_LOCAL_NAME.module.server.google_organization_iam_member.org_read[5]" "$ORG_ID roles/compute.networkViewer serviceAccount:forseti-server-gcp-$RESOURCE_NAME_SUFFIX@$PROJECT_ID.iam.gserviceaccount.com"
+terraform import "module.$MODULE_LOCAL_NAME.module.server.google_organization_iam_member.org_read[6]" "$ORG_ID roles/iam.securityReviewer serviceAccount:forseti-server-gcp-$RESOURCE_NAME_SUFFIX@$PROJECT_ID.iam.gserviceaccount.com"
+terraform import "module.$MODULE_LOCAL_NAME.module.server.google_organization_iam_member.org_read[7]" "$ORG_ID roles/orgpolicy.policyViewer serviceAccount:forseti-server-gcp-$RESOURCE_NAME_SUFFIX@$PROJECT_ID.iam.gserviceaccount.com"
+terraform import "module.$MODULE_LOCAL_NAME.module.server.google_organization_iam_member.org_read[8]" "$ORG_ID roles/servicemanagement.quotaViewer serviceAccount:forseti-server-gcp-$RESOURCE_NAME_SUFFIX@$PROJECT_ID.iam.gserviceaccount.com"
+terraform import "module.$MODULE_LOCAL_NAME.module.server.google_organization_iam_member.org_read[9]" "$ORG_ID roles/serviceusage.serviceUsageConsumer serviceAccount:forseti-server-gcp-$RESOURCE_NAME_SUFFIX@$PROJECT_ID.iam.gserviceaccount.com"
+terraform import "module.$MODULE_LOCAL_NAME.module.server.google_organization_iam_member.org_write[0]" "$ORG_ID roles/compute.securityAdmin serviceAccount:forseti-server-gcp-$RESOURCE_NAME_SUFFIX@$PROJECT_ID.iam.gserviceaccount.com"
+terraform import "module.$MODULE_LOCAL_NAME.module.server.google_compute_firewall.forseti-server-deny-all" "$PROJECT_ID/forseti-server-deny-all-$RESOURCE_NAME_SUFFIX"
+terraform import "module.$MODULE_LOCAL_NAME.module.server.google_compute_firewall.forseti-server-ssh-external" "$PROJECT_ID/forseti-server-allow-ssh-external-$RESOURCE_NAME_SUFFIX"
+terraform import "module.$MODULE_LOCAL_NAME.module.server.google_compute_firewall.forseti-server-allow-grpc" "$PROJECT_ID/forseti-server-allow-grpc-$RESOURCE_NAME_SUFFIX"
+terraform import "module.$MODULE_LOCAL_NAME.module.server.google_storage_bucket.server_config" "$PROJECT_ID/forseti-server-$RESOURCE_NAME_SUFFIX"
+terraform import "module.$MODULE_LOCAL_NAME.module.server.google_storage_bucket.cai_export" "$PROJECT_ID/forseti-cai-export-$RESOURCE_NAME_SUFFIX"
+terraform import "module.$MODULE_LOCAL_NAME.module.server.google_compute_instance.forseti-server" "$PROJECT_ID/us-central1-c/forseti-server-vm-$RESOURCE_NAME_SUFFIX"
+terraform import "module.$MODULE_LOCAL_NAME.module.server.google_sql_database_instance.master" "$PROJECT_ID/forseti-server-db-$RESOURCE_NAME_SUFFIX"
+terraform import "module.$MODULE_LOCAL_NAME.module.server.google_sql_database.forseti-db" "$PROJECT_ID/forseti-server-db-$RESOURCE_NAME_SUFFIX/forseti_security"
+terraform import "module.$MODULE_LOCAL_NAME.module.server.google_sql_user.root" "$PROJECT_ID/forseti-server-db-$RESOURCE_NAME_SUFFIX/%/root"
+
+printf "\n\nFinished import of Forseti resources to Terraform\n"

--- a/helpers/import.sh
+++ b/helpers/import.sh
@@ -76,7 +76,7 @@ NETWORK_PROJECT_ID=""
 ORG_ID=""
 PROJECT_ID=""
 RESOURCE_NAME_SUFFIX=""
-while getopts ":hm:o:p:r:" opt; do
+while getopts ":hm:n:o:p:r:" opt; do
   case ${opt} in
     h )
       show_help

--- a/helpers/import.sh
+++ b/helpers/import.sh
@@ -41,7 +41,7 @@ Example of required Terraform configuration:
 
     module "forseti" {
       source = "terraform-google-modules/forseti/google"
-      version = "~> 4.1"
+      version = "~> 4.2"
 
       domain               = "DOMAIN"
       project_id           = "PROJECT_ID"

--- a/main.tf
+++ b/main.tf
@@ -204,6 +204,7 @@ module "server" {
   group_enabled                                       = var.group_enabled
   forwarding_rule_enabled                             = var.forwarding_rule_enabled
   firewall_rule_enabled                               = var.firewall_rule_enabled
+  manage_rules_enabled                                = var.manage_rules_enabled
   enabled_apis_enabled                                = var.enabled_apis_enabled
   cloudsql_acl_enabled                                = var.cloudsql_acl_enabled
   config_validator_enabled                            = var.config_validator_enabled

--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ resource "null_resource" "email_without_sendgrid_api_key" {
 # Locals #
 #--------#
 locals {
-  random_hash     = random_id.random_hash_suffix.hex
+  random_hash     = var.resource_name_suffix == null ? random_id.random_hash_suffix.hex : var.resource_name_suffix
   network_project = var.network_project != "" ? var.network_project : var.project_id
 
   services_list = [

--- a/modules/client/main.tf
+++ b/modules/client/main.tf
@@ -152,7 +152,7 @@ resource "google_compute_instance" "forseti-client" {
 #------------------------#
 resource "google_compute_firewall" "forseti-client-deny-all" {
   name                    = "forseti-client-deny-all-${var.suffix}"
-  project                 = var.network_project
+  project                 = local.network_project
   network                 = var.network
   target_service_accounts = [google_service_account.forseti_client.email]
   source_ranges           = ["0.0.0.0/0"]
@@ -175,7 +175,7 @@ resource "google_compute_firewall" "forseti-client-deny-all" {
 
 resource "google_compute_firewall" "forseti-client-ssh-external" {
   name                    = "forseti-client-ssh-external-${var.suffix}"
-  project                 = var.network_project
+  project                 = local.network_project
   network                 = var.network
   target_service_accounts = [google_service_account.forseti_client.email]
   source_ranges           = var.client_ssh_allow_ranges
@@ -231,4 +231,3 @@ resource "null_resource" "services-dependency" {
     services = jsonencode(var.services)
   }
 }
-

--- a/modules/rules/main.tf
+++ b/modules/rules/main.tf
@@ -41,10 +41,12 @@ locals {
     "rules/role_rules.yaml",
     "rules/service_account_key_rules.yaml",
   ]
+
+  rules_count = var.manage_rules_enabled ? length(local.files) : 0
 }
 
 data "template_file" "main" {
-  count = length(local.files)
+  count = local.rules_count
   template = file(
     "${path.module}/templates/${element(local.files, count.index)}",
   )
@@ -56,7 +58,7 @@ data "template_file" "main" {
 }
 
 resource "google_storage_bucket_object" "main" {
-  count   = length(local.files)
+  count   = local.rules_count
   name    = element(local.files, count.index)
   content = element(data.template_file.main.*.rendered, count.index)
   bucket  = var.bucket
@@ -68,4 +70,3 @@ resource "google_storage_bucket_object" "main" {
     ]
   }
 }
-

--- a/modules/rules/variables.tf
+++ b/modules/rules/variables.tf
@@ -19,6 +19,12 @@ variable "bucket" {
   type        = string
 }
 
+variable "manage_rules_enabled" {
+  description = "A toggle to enable or disable the management of rules"
+  type        = bool
+  default     = true
+}
+
 variable "org_id" {
   description = "The organization ID"
 }
@@ -26,4 +32,3 @@ variable "org_id" {
 variable "domain" {
   description = "The domain associated with the GCP Organization ID"
 }
-

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -405,10 +405,11 @@ resource "google_storage_bucket_object" "forseti_server_config" {
 }
 
 module "server_rules" {
-  source = "../rules"
-  bucket = google_storage_bucket.server_config.name
-  org_id = var.org_id
-  domain = var.domain
+  source               = "../rules"
+  bucket               = google_storage_bucket.server_config.name
+  org_id               = var.org_id
+  domain               = var.domain
+  manage_rules_enabled = var.manage_rules_enabled
 }
 
 resource "google_storage_bucket" "cai_export" {

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -385,6 +385,12 @@ variable "log_sink_enabled" {
   default     = "true"
 }
 
+variable "manage_rules_enabled" {
+  description = "A toggle to enable or disable the management of rules"
+  type        = bool
+  default     = true
+}
+
 variable "policy_library_home" {
   description = "The local policy library directory."
   default     = "$USER_HOME/policy-library"

--- a/variables.tf
+++ b/variables.tf
@@ -56,6 +56,12 @@ variable "forseti_run_frequency" {
   default     = "0 */2 * * *"
 }
 
+variable "resource_name_suffix" {
+  default     = null
+  description = "A suffix which will be appended to resource names."
+  type        = string
+}
+
 #----------------#
 # Forseti server #
 #----------------#

--- a/variables.tf
+++ b/variables.tf
@@ -457,6 +457,12 @@ variable "log_sink_enabled" {
   default     = "true"
 }
 
+variable "manage_rules_enabled" {
+  description = "A toggle to enable or disable the management of rules"
+  type        = bool
+  default     = true
+}
+
 variable "policy_library_home" {
   description = "The local policy library directory."
   default     = "$USER_HOME/policy-library"


### PR DESCRIPTION
This branch adds support for importing existing Forseti installations. It adds variables to override the random resource name suffix and toggle rule management.

Fixes #197.