### PR TITLE
Update variables.tf

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -802,7 +802,6 @@ variable "enable_cai_bucket" {
 #--------#
 variable "org_id" {
   description = "GCP Organization ID that Forseti will have purview over"
-  default     = ""
 }
 
 variable "domain" {


### PR DESCRIPTION
removing empty default string from `org_id` variable. If you submit this var as an empty string, `count = length(var.composite_root_resources) == 0 && var.org_id == "" && var.folder_id == "" ? 1 : 0` in main.tf fails on v11 and v12 of terraform.

Users need to specify a value for `org_id`.