### PR TITLE
CloudSQL instance created in the same zone as GCE instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Extending the adopted spec, each change should have a link to its corresponding pull request appended.
 
+## [v4.2.0] - 2019-09-19
+
+### Added
+
+- CloudSQL instance created in the same zone as GCE instances [#253]
+
 ## [v4.1.0] - 2019-09-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Extending the adopted spec, each change should have a link to its corresponding pull request appended.
 
-## [v4.2.0] - 2019-09-19
+## [Unreleased]
 
 ### Added
 
@@ -251,6 +251,7 @@ Version 4.0.0 is a backwards-incompatible release. Please see the [upgrade instr
 [v4.0.1]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v4.0.0...v4.0.1
 [v4.1.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v4.0.1...v4.1.0
 
+[#253]: https://github.com/forseti-security/terraform-google-forseti/pull/253
 [#246]: https://github.com/forseti-security/terraform-google-forseti/pull/246
 [#239]: https://github.com/forseti-security/terraform-google-forseti/pull/239
 [#233]: https://github.com/forseti-security/terraform-google-forseti/pull/233

--- a/modules/client/variables.tf
+++ b/modules/client/variables.tf
@@ -40,17 +40,17 @@ variable "forseti_home" {
 # Forseti client #
 #----------------#
 variable "client_type" {
-  description = "GCE Forseti Client role instance size"
+  description = "GCE Forseti Client machine type"
   default     = "n1-standard-2"
 }
 
 variable "client_boot_image" {
-  description = "GCE Forseti Client role instance size"
+  description = "GCE Forseti Client boot image"
   default     = "ubuntu-os-cloud/ubuntu-1804-lts"
 }
 
 variable "client_region" {
-  description = "GCE Forseti Client role region size"
+  description = "GCE Forseti Client region"
   default     = "us-central1"
 }
 
@@ -116,4 +116,3 @@ variable "services" {
   type        = list(string)
   default     = []
 }
-

--- a/modules/cloudsql/main.tf
+++ b/modules/cloudsql/main.tf
@@ -21,22 +21,22 @@ locals {
   random_hash     = var.suffix
   cloudsql_name   = "forseti-server-db-${local.random_hash}"
   network_project = var.network_project != "" ? var.network_project : var.project_id
+  cloudsql_zone   = "${var.cloudsql_region}-c"
 }
 
 #------------------------------------#
 # Forseti Private SQL Database Setup #
 #------------------------------------#
-
 data "google_compute_network" "cloudsql_private_network" {
-  name    = "${var.network}"
-  project = "${local.network_project}"
+  name    = var.network
+  project = local.network_project
 }
 
 resource "google_project_service" "service_networking" {
   count              = var.cloudsql_private ? 1 : 0
   project            = var.project_id
   service            = "servicenetworking.googleapis.com"
-  disable_on_destroy = "false"
+  disable_on_destroy = false
 }
 
 resource "google_compute_global_address" "private_ip_address" {
@@ -60,7 +60,6 @@ resource "google_service_networking_connection" "private_vpc_connection" {
 #----------------------#
 # Forseti SQL database #
 #----------------------#
-
 resource "google_sql_database_instance" "master" {
   name             = local.cloudsql_name
   project          = var.project_id
@@ -78,9 +77,13 @@ resource "google_sql_database_instance" "master" {
     }
 
     ip_configuration {
-      ipv4_enabled    = var.cloudsql_private ? "false" : "true"
+      ipv4_enabled    = var.cloudsql_private ? false : true
       require_ssl     = true
       private_network = var.cloudsql_private ? data.google_compute_network.cloudsql_private_network.self_link : ""
+    }
+
+    location_preference {
+      zone = local.cloudsql_zone
     }
   }
   depends_on = [null_resource.services-dependency, "google_service_networking_connection.private_vpc_connection"]

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -577,17 +577,17 @@ variable "inventory_email_summary_enabled" {
 # Forseti server #
 #----------------#
 variable "server_type" {
-  description = "GCE Forseti Server role instance size"
+  description = "GCE Forseti Server machine type"
   default     = "n1-standard-2"
 }
 
 variable "server_region" {
-  description = "GCP region where Forseti will be deployed"
+  description = "GCE Forseti Server region"
   default     = "us-central1"
 }
 
 variable "server_boot_image" {
-  description = "GCE instance image that is being used, currently Debian only support is available"
+  description = "GCE Forseti Server boot image - Currently only Ubuntu is supported"
   default     = "ubuntu-os-cloud/ubuntu-1804-lts"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -60,17 +60,17 @@ variable "forseti_run_frequency" {
 # Forseti server #
 #----------------#
 variable "server_type" {
-  description = "GCE Forseti Server role instance size"
+  description = "GCE Forseti Server machine type"
   default     = "n1-standard-2"
 }
 
 variable "server_region" {
-  description = "GCP region where Forseti will be deployed"
+  description = "GCE Forseti Server region"
   default     = "us-central1"
 }
 
 variable "server_boot_image" {
-  description = "GCE instance image that is being used, currently Ubuntu only support is available"
+  description = "GCE Forseti Server boot image - Currently only Ubuntu is supported"
   default     = "ubuntu-os-cloud/ubuntu-1804-lts"
 }
 
@@ -674,17 +674,17 @@ variable "groups_settings_violations_should_notify" {
 # Forseti client #
 #----------------#
 variable "client_type" {
-  description = "GCE Forseti Client role instance size"
+  description = "GCE Forseti Client machine type"
   default     = "n1-standard-2"
 }
 
 variable "client_boot_image" {
-  description = "GCE Forseti Client role instance size"
+  description = "GCE Forseti Client boot image"
   default     = "ubuntu-os-cloud/ubuntu-1804-lts"
 }
 
 variable "client_region" {
-  description = "GCE Forseti Client role region size"
+  description = "GCE Forseti Client region"
   default     = "us-central1"
 }
 


### PR DESCRIPTION
Set the Zone for the CloudSQL instance to the same way that is being done for the client and server. Minor cleanup changes.

Resolves [Forseti issue #3194](https://github.com/forseti-security/forseti-security/issues/3194).