### PR TITLE
Required vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Simple usage of the module within your own main.tf file is as follows:
 | subnetwork | The VPC subnetwork where the Forseti client and server will be created | string | `"default"` | no |
 | violations\_slack\_webhook | Slack webhook for any violation. Will apply to all scanner violation notifiers. | string | `""` | no |
 
-__**__ Either the folder\_id or org\_id input is required to be set for a simple deployment.
+** Either the **folder\_id** or **org\_id** input is required to be set for a simple deployment.
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Simple usage of the module within your own main.tf file is as follows:
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 
+Either the **folder\_id** or **org\_id** input is required to successfully deploy the Forseti module.
+
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | admin\_disable\_polling | Whether to disable polling for Admin API | bool | `"false"` | no |
@@ -100,7 +102,7 @@ Simple usage of the module within your own main.tf file is as follows:
 | external\_project\_access\_violations\_should\_notify | Notify for External Project Access violations | string | `"true"` | no |
 | firewall\_rule\_enabled | Firewall rule scanner enabled. | string | `"true"` | no |
 | firewall\_rule\_violations\_should\_notify | Notify for Firewall rule violations | string | `"true"` | no |
-| folder\_id | GCP Folder that the Forseti project will be deployed into | string | `""` | no** |
+| folder\_id | GCP Folder that the Forseti project will be deployed into | string | `""` | no |
 | forseti\_email\_recipient | Email address that receives Forseti notifications | string | `""` | no |
 | forseti\_email\_sender | Email address that sends the Forseti notifications | string | `""` | no |
 | forseti\_home | Forseti installation directory | string | `"$USER_HOME/forseti-security"` | no |
@@ -148,7 +150,7 @@ Simple usage of the module within your own main.tf file is as follows:
 | logging\_period | The period of max calls for the Logging API (in seconds) | string | `"1.0"` | no |
 | network | The VPC where the Forseti client and server will be created | string | `"default"` | no |
 | network\_project | The project containing the VPC and subnetwork where the Forseti client and server will be created | string | `""` | no |
-| org\_id | GCP Organization ID that Forseti will have purview over | string | `""` | no** |
+| org\_id | GCP Organization ID that Forseti will have purview over | string | `""` | no |
 | policy\_library\_home | The local policy library directory. | string | `"$USER_HOME/policy-library"` | no |
 | policy\_library\_repository\_url | The git repository containing the policy-library. | string | `""` | no |
 | policy\_library\_sync\_enabled | Sync config validator policy library from private repository. | bool | `"false"` | no |
@@ -185,8 +187,6 @@ Simple usage of the module within your own main.tf file is as follows:
 | storage\_disable\_polling | Whether to disable polling for Storage API | bool | `"false"` | no |
 | subnetwork | The VPC subnetwork where the Forseti client and server will be created | string | `"default"` | no |
 | violations\_slack\_webhook | Slack webhook for any violation. Will apply to all scanner violation notifiers. | string | `""` | no |
-
-** Either the **folder\_id** or **org\_id** input is required to be set for a simple deployment.
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ Simple usage of the module within your own main.tf file is as follows:
 | bucket\_cai\_location | GCS CAI storage bucket location | string | `"us-central1"` | no |
 | buckets\_acl\_violations\_should\_notify | Notify for Buckets ACL violations | string | `"true"` | no |
 | cai\_api\_timeout | Timeout in seconds to wait for the exportAssets API to return success. | string | `"3600"` | no |
-| client\_access\_config | Client instance 'access_config' block | map(any) | `<map>` | no |
+| client\_access\_config | Client instance 'access\_config' block | map(any) | `<map>` | no |
 | client\_boot\_image | GCE Forseti Client role instance size | string | `"ubuntu-os-cloud/ubuntu-1804-lts"` | no |
 | client\_instance\_metadata | Metadata key/value pairs to make available from within the client instance. | map(string) | `<map>` | no |
-| client\_private | Private GCE Forseti Client VM (no public IP) | string | `"false"` | no |
+| client\_private | Private GCE Forseti Client VM (no public IP) | bool | `"false"` | no |
 | client\_region | GCE Forseti Client role region size | string | `"us-central1"` | no |
 | client\_ssh\_allow\_ranges | List of CIDRs that will be allowed ssh access to forseti client | list(string) | `<list>` | no |
 | client\_tags | GCE Forseti Client VM Tags | list(string) | `<list>` | no |
@@ -71,11 +71,13 @@ Simple usage of the module within your own main.tf file is as follows:
 | cloudsql\_acl\_violations\_should\_notify | Notify for CloudSQL ACL violations | string | `"true"` | no |
 | cloudsql\_db\_name | CloudSQL database name | string | `"forseti_security"` | no |
 | cloudsql\_db\_port | CloudSQL database port | string | `"3306"` | no |
+| cloudsql\_disk\_size | The size of data disk, in GB. Size of a running instance cannot be reduced but can be increased. | string | `"25"` | no |
+| cloudsql\_private | Whether to enable private network and not to create public IP for CloudSQL Instance | bool | `"false"` | no |
 | cloudsql\_proxy\_arch | CloudSQL Proxy architecture | string | `"linux.amd64"` | no |
 | cloudsql\_region | CloudSQL region | string | `"us-central1"` | no |
 | cloudsql\_type | CloudSQL Instance size | string | `"db-n1-standard-1"` | no |
 | cloudsql\_user\_host | The host the user can connect from.  Can be an IP address or IP address range. Changing this forces a new resource to be created. | string | `"%"` | no |
-| composite\_root\_resources | A list of root resources that Forseti will monitor. This supersedes the root_resource_id when set. | list(string) | `<list>` | no |
+| composite\_root\_resources | A list of root resources that Forseti will monitor. This supersedes the root\_resource\_id when set. | list(string) | `<list>` | no |
 | compute\_disable\_polling | Whether to disable polling for Compute API | bool | `"false"` | no |
 | compute\_max\_calls | Maximum calls that can be made to Compute API | string | `"18"` | no |
 | compute\_period | The period of max calls for the Compute API (in seconds) | string | `"1.0"` | no |
@@ -94,7 +96,7 @@ Simple usage of the module within your own main.tf file is as follows:
 | enable\_write | Enabling/Disabling write actions | string | `"false"` | no |
 | enabled\_apis\_enabled | Enabled APIs scanner enabled. | string | `"false"` | no |
 | enabled\_apis\_violations\_should\_notify | Notify for enabled APIs violations | string | `"true"` | no |
-| excluded\_resources | Resources to be excluded during the inventory phase. | list | `[]` | no |
+| excluded\_resources | A list of resources to exclude during the inventory phase. | list(string) | `<list>` | no |
 | external\_project\_access\_violations\_should\_notify | Notify for External Project Access violations | string | `"true"` | no |
 | firewall\_rule\_enabled | Firewall rule scanner enabled. | string | `"true"` | no |
 | firewall\_rule\_violations\_should\_notify | Notify for Firewall rule violations | string | `"true"` | no |
@@ -102,9 +104,9 @@ Simple usage of the module within your own main.tf file is as follows:
 | forseti\_email\_recipient | Email address that receives Forseti notifications | string | `""` | no |
 | forseti\_email\_sender | Email address that sends the Forseti notifications | string | `""` | no |
 | forseti\_home | Forseti installation directory | string | `"$USER_HOME/forseti-security"` | no |
-| forseti\_repo\_url | Git repo for the Forseti installation | string | `"https://github.com/GoogleCloudPlatform/forseti-security"` | no |
+| forseti\_repo\_url | Git repo for the Forseti installation | string | `"https://github.com/forseti-security/forseti-security"` | no |
 | forseti\_run\_frequency | Schedule of running the Forseti scans | string | `"0 */2 * * *"` | no |
-| forseti\_version | The version of Forseti to install | string | `"v2.19.1"` | no |
+| forseti\_version | The version of Forseti to install | string | `"v2.20.0"` | no |
 | forwarding\_rule\_enabled | Forwarding rule scanner enabled. | string | `"false"` | no |
 | forwarding\_rule\_violations\_should\_notify | Notify for forwarding rule violations | string | `"true"` | no |
 | group\_enabled | Group scanner enabled. | string | `"true"` | no |
@@ -147,12 +149,12 @@ Simple usage of the module within your own main.tf file is as follows:
 | network | The VPC where the Forseti client and server will be created | string | `"default"` | no |
 | network\_project | The project containing the VPC and subnetwork where the Forseti client and server will be created | string | `""` | no |
 | org\_id | GCP Organization ID that Forseti will have purview over | string | `""` | no** |
-| policy\_library\_home | The local policy library directory | string | `"$USER_HOME/policy-library"` | no |
+| policy\_library\_home | The local policy library directory. | string | `"$USER_HOME/policy-library"` | no |
 | policy\_library\_repository\_url | The git repository containing the policy-library. | string | `""` | no |
-| policy\_library\_sync\_enabled | Sync config validator policy library from private repository | string | `"false"` | no |
-| policy\_library\_sync\_gcs\_directory\_name | The directory name of the GCS folder used for the policy library sync config | string | `"policy_library_sync"` | no |
-| policy\_library\_sync\_git\_sync\_tag | Tag for the git-sync image | string | `"v3.1.2"` | no |
-| policy\_library\_sync\_ssh\_known\_hosts | List of authorized public keys for SSH host of the policy library repository| string | `""` | no |
+| policy\_library\_sync\_enabled | Sync config validator policy library from private repository. | bool | `"false"` | no |
+| policy\_library\_sync\_gcs\_directory\_name | The directory name of the GCS folder used for the policy library sync config. | string | `"policy_library_sync"` | no |
+| policy\_library\_sync\_git\_sync\_tag | Tag for the git-sync image. | string | `"v3.1.2"` | no |
+| policy\_library\_sync\_ssh\_known\_hosts | List of authorized public keys for SSH host of the policy library repository. | string | `""` | no |
 | project\_id | Google Project ID that you want Forseti deployed into | string | n/a | yes |
 | resource\_enabled | Resource scanner enabled. | string | `"true"` | no |
 | resource\_violations\_should\_notify | Notify for resource violations | string | `"true"` | no |
@@ -160,13 +162,13 @@ Simple usage of the module within your own main.tf file is as follows:
 | securitycenter\_max\_calls | Maximum calls that can be made to Security Center API | string | `"1"` | no |
 | securitycenter\_period | The period of max calls for the Security Center API (in seconds) | string | `"1.1"` | no |
 | sendgrid\_api\_key | Sendgrid.com API key to enable email notifications | string | `""` | no |
-| server\_access\_config | Server instance 'access_config' block | map(any) | `<map>` | no |
+| server\_access\_config | Server instance 'access\_config' block | map(any) | `<map>` | no |
+| server\_boot\_disk\_size | Size of the GCE instance boot disk in GBs. | string | `"100"` | no |
+| server\_boot\_disk\_type | GCE instance boot disk type, can be pd-standard or pd-ssd. | string | `"pd-ssd"` | no |
 | server\_boot\_image | GCE instance image that is being used, currently Ubuntu only support is available | string | `"ubuntu-os-cloud/ubuntu-1804-lts"` | no |
-| server\_boot\_disk\_size | Size of the GCE instance boot disk in GBs | string | `"100"` | no |
-| server\_boot\_disk\_type | GCE instance boot disk type, can be pd-standard or pd-ssd | string | `"pd-ssd"` | no |
 | server\_grpc\_allow\_ranges | List of CIDRs that will be allowed gRPC access to forseti server | list(string) | `<list>` | no |
 | server\_instance\_metadata | Metadata key/value pairs to make available from within the server instance. | map(string) | `<map>` | no |
-| server\_private | Private GCE Forseti Server VM (no public IP) | string | `"false"` | no |
+| server\_private | Private GCE Forseti Server VM (no public IP) | bool | `"false"` | no |
 | server\_region | GCP region where Forseti will be deployed | string | `"us-central1"` | no |
 | server\_ssh\_allow\_ranges | List of CIDRs that will be allowed ssh access to forseti server | list(string) | `<list>` | no |
 | server\_tags | GCE Forseti Server VM Tags | list(string) | `<list>` | no |
@@ -180,7 +182,7 @@ Simple usage of the module within your own main.tf file is as follows:
 | sqladmin\_max\_calls | Maximum calls that can be made to SQL Admin API | string | `"1"` | no |
 | sqladmin\_period | The period of max calls for the SQL Admin API (in seconds) | string | `"1.1"` | no |
 | storage\_bucket\_location | GCS storage bucket location | string | `"us-central1"` | no |
-| storage\_disable\_polling | Whetservicemanagement_disable_pollingher to disable polling for Storage API | bool | `"false"` | no |
+| storage\_disable\_polling | Whether to disable polling for Storage API | bool | `"false"` | no |
 | subnetwork | The VPC subnetwork where the Forseti client and server will be created | string | `"default"` | no |
 | violations\_slack\_webhook | Slack webhook for any violation. Will apply to all scanner violation notifiers. | string | `""` | no |
 
@@ -195,7 +197,7 @@ Simple usage of the module within your own main.tf file is as follows:
 | forseti-client-vm-ip | Forseti Client VM private IP address |
 | forseti-client-vm-name | Forseti Client VM name |
 | forseti-cloudsql-connection-name | Forseti CloudSQL Connection String |
-| forseti-server-git-public-key-openssh | The public OpenSSH key generated to allow the Forseti Server to clone the policy library repository |
+| forseti-server-git-public-key-openssh | The public OpenSSH key generated to allow the Forseti Server to clone the policy library repository. |
 | forseti-server-service-account | Forseti Server service account |
 | forseti-server-storage-bucket | Forseti Server storage bucket |
 | forseti-server-vm-ip | Forseti Server VM private IP address |

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Simple usage of the module within your own main.tf file is as follows:
 | external\_project\_access\_violations\_should\_notify | Notify for External Project Access violations | string | `"true"` | no |
 | firewall\_rule\_enabled | Firewall rule scanner enabled. | string | `"true"` | no |
 | firewall\_rule\_violations\_should\_notify | Notify for Firewall rule violations | string | `"true"` | no |
-| folder\_id | GCP Folder that the Forseti project will be deployed into | string | `""` | no |
+| folder\_id | GCP Folder that the Forseti project will be deployed into | string | `""` | no** |
 | forseti\_email\_recipient | Email address that receives Forseti notifications | string | `""` | no |
 | forseti\_email\_sender | Email address that sends the Forseti notifications | string | `""` | no |
 | forseti\_home | Forseti installation directory | string | `"$USER_HOME/forseti-security"` | no |
@@ -146,7 +146,7 @@ Simple usage of the module within your own main.tf file is as follows:
 | logging\_period | The period of max calls for the Logging API (in seconds) | string | `"1.0"` | no |
 | network | The VPC where the Forseti client and server will be created | string | `"default"` | no |
 | network\_project | The project containing the VPC and subnetwork where the Forseti client and server will be created | string | `""` | no |
-| org\_id | GCP Organization ID that Forseti will have purview over | string | `""` | no |
+| org\_id | GCP Organization ID that Forseti will have purview over | string | `""` | no** |
 | policy\_library\_home | The local policy library directory | string | `"$USER_HOME/policy-library"` | no |
 | policy\_library\_repository\_url | The git repository containing the policy-library. | string | `""` | no |
 | policy\_library\_sync\_enabled | Sync config validator policy library from private repository | string | `"false"` | no |
@@ -183,6 +183,8 @@ Simple usage of the module within your own main.tf file is as follows:
 | storage\_disable\_polling | Whetservicemanagement_disable_pollingher to disable polling for Storage API | bool | `"false"` | no |
 | subnetwork | The VPC subnetwork where the Forseti client and server will be created | string | `"default"` | no |
 | violations\_slack\_webhook | Slack webhook for any violation. Will apply to all scanner violation notifiers. | string | `""` | no |
+
+__**__ Either the folder\_id or org\_id input is required to be set for a simple deployment.
 
 ## Outputs
 


### PR DESCRIPTION
Added a note to the `org_id` and `folder_id` vars that one or the other is required for a simple deployment. Open to suggestions on better ways to notate the requirements.