### PR TITLE
Added sql instance user and password.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ your environment.
 | cloudsql\_acl\_violations\_should\_notify | Notify for CloudSQL ACL violations | bool | `"true"` | no |
 | cloudsql\_db\_name | CloudSQL database name | string | `"forseti_security"` | no |
 | cloudsql\_db\_port | CloudSQL database port | string | `"3306"` | no |
+| cloudsql\_db\_user | CloudSQL database name | string | `"forseti_security_user"` | no |
+| cloudsql\_db\_password | CloudSQL database name | string | `a randomized password` | no |
 | cloudsql\_disk\_size | The size of data disk, in GB. Size of a running instance cannot be reduced but can be increased. | string | `"25"` | no |
 | cloudsql\_net\_write\_timeout | See MySQL documentation: https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_net_write_timeout | string | `"240"` | no |
 | cloudsql\_private | Whether to enable private network and not to create public IP for CloudSQL Instance | bool | `"false"` | no |

--- a/README.md
+++ b/README.md
@@ -201,9 +201,9 @@ For this module to work, you need the following APIs enabled on the Forseti proj
 | cloudsql\_acl\_enabled | Cloud SQL scanner enabled. | bool | `"true"` | no |
 | cloudsql\_acl\_violations\_should\_notify | Notify for CloudSQL ACL violations | bool | `"true"` | no |
 | cloudsql\_db\_name | CloudSQL database name | string | `"forseti_security"` | no |
+| cloudsql\_db\_password | CloudSQL database password | string | `""` | no |
 | cloudsql\_db\_port | CloudSQL database port | string | `"3306"` | no |
-| cloudsql\_user | CloudSQL user | string | `"forseti_security_user"` | no |
-| cloudsql\_password | CloudSQL password | string | `a randomized password` | no |
+| cloudsql\_db\_user | CloudSQL database user | string | `"forseti_security_user"` | no |
 | cloudsql\_disk\_size | The size of data disk, in GB. Size of a running instance cannot be reduced but can be increased. | string | `"25"` | no |
 | cloudsql\_net\_write\_timeout | See MySQL documentation: https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_net_write_timeout | string | `"240"` | no |
 | cloudsql\_private | Whether to enable private network and not to create public IP for CloudSQL Instance | bool | `"false"` | no |

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ your environment.
 | cloudsql\_acl\_violations\_should\_notify | Notify for CloudSQL ACL violations | bool | `"true"` | no |
 | cloudsql\_db\_name | CloudSQL database name | string | `"forseti_security"` | no |
 | cloudsql\_db\_port | CloudSQL database port | string | `"3306"` | no |
-| cloudsql\_db\_user | CloudSQL database name | string | `"forseti_security_user"` | no |
-| cloudsql\_db\_password | CloudSQL database name | string | `a randomized password` | no |
+| cloudsql\_user | CloudSQL user | string | `"forseti_security_user"` | no |
+| cloudsql\_password | CloudSQL password | string | `a randomized password` | no |
 | cloudsql\_disk\_size | The size of data disk, in GB. Size of a running instance cannot be reduced but can be increased. | string | `"25"` | no |
 | cloudsql\_net\_write\_timeout | See MySQL documentation: https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_net_write_timeout | string | `"240"` | no |
 | cloudsql\_private | Whether to enable private network and not to create public IP for CloudSQL Instance | bool | `"false"` | no |

--- a/modules/cloudsql/main.tf
+++ b/modules/cloudsql/main.tf
@@ -18,11 +18,11 @@
 # Locals #
 #--------#
 locals {
-  cloudsql_name   = "forseti-server-db-${local.random_hash}"
-  cloudsql_zone   = "${var.cloudsql_region}-c"
-  network_project = var.network_project != "" ? var.network_project : var.project_id
+  cloudsql_name     = "forseti-server-db-${local.random_hash}"
+  cloudsql_zone     = "${var.cloudsql_region}-c"
+  network_project   = var.network_project != "" ? var.network_project : var.project_id
   cloudsql_password = var.cloudsql_password == "" ? random_password.password.result : var.cloudsql_password
-  random_hash     = var.suffix
+  random_hash       = var.suffix
 }
 
 #------------------------------------#
@@ -111,8 +111,8 @@ resource "google_sql_user" "forseti_user" {
 }
 
 resource "random_password" "password" {
-  length = 16
-  special = true
+  length           = 16
+  special          = true
   override_special = "_%@"
 }
 

--- a/modules/cloudsql/main.tf
+++ b/modules/cloudsql/main.tf
@@ -21,7 +21,7 @@ locals {
   random_hash     = var.suffix
   cloudsql_name   = "forseti-server-db-${local.random_hash}"
   network_project = var.network_project != "" ? var.network_project : var.project_id
-  cloudsql_db_password = var.cloudsql_db_password == "" ? random_password.password.result : var.cloudsql_db_password
+  cloudsql_db_password = var.cloudsql_password == "" ? random_password.password.result : var.cloudsql_password
 }
 
 #------------------------------------#
@@ -99,8 +99,8 @@ resource "google_sql_database" "forseti-db" {
   instance = google_sql_database_instance.master.name
 }
 
-resource "google_sql_user" "forseti_db_user" {
-  name     = var.cloudsql_db_user
+resource "google_sql_user" "forseti_user" {
+  name     = var.cloudsql_user
   instance = google_sql_database_instance.master.name
   project  = var.project_id
   host     = var.cloudsql_user_host

--- a/modules/cloudsql/main.tf
+++ b/modules/cloudsql/main.tf
@@ -21,7 +21,7 @@ locals {
   random_hash     = var.suffix
   cloudsql_name   = "forseti-server-db-${local.random_hash}"
   network_project = var.network_project != "" ? var.network_project : var.project_id
-  cloudsql_db_password = var.cloudsql_password == "" ? random_password.password.result : var.cloudsql_password
+  cloudsql_password = var.cloudsql_password == "" ? random_password.password.result : var.cloudsql_password
 }
 
 #------------------------------------#
@@ -104,7 +104,7 @@ resource "google_sql_user" "forseti_user" {
   instance = google_sql_database_instance.master.name
   project  = var.project_id
   host     = var.cloudsql_user_host
-  password = local.cloudsql_db_password
+  password = local.cloudsql_password
 }
 
 resource "random_password" "password" {

--- a/modules/cloudsql/main.tf
+++ b/modules/cloudsql/main.tf
@@ -21,6 +21,7 @@ locals {
   random_hash     = var.suffix
   cloudsql_name   = "forseti-server-db-${local.random_hash}"
   network_project = var.network_project != "" ? var.network_project : var.project_id
+  cloudsql_db_password = var.cloudsql_db_password == "" ? random_password.password.result : var.cloudsql_db_password
 }
 
 #------------------------------------#
@@ -98,11 +99,18 @@ resource "google_sql_database" "forseti-db" {
   instance = google_sql_database_instance.master.name
 }
 
-resource "google_sql_user" "root" {
-  name     = "root"
+resource "google_sql_user" "forseti_db_user" {
+  name     = var.cloudsql_db_user
   instance = google_sql_database_instance.master.name
   project  = var.project_id
   host     = var.cloudsql_user_host
+  password = local.cloudsql_db_password
+}
+
+resource "random_password" "password" {
+  length = 16
+  special = true
+  override_special = "_%@"
 }
 
 resource "null_resource" "services-dependency" {

--- a/modules/cloudsql/outputs.tf
+++ b/modules/cloudsql/outputs.tf
@@ -41,10 +41,10 @@ output "forseti-clodusql-db-port" {
 
 output "forseti-cloudsql-user" {
   description = "CloudSQL user"
-  value       = var.cloudsql_db_user
+  value       = var.cloudsql_user
 }
 
 output "forseti-cloudsql-password" {
   description = "CloudSQL password"
-  value       = var.cloudsql_db_password
+  value       = var.cloudsql_password
 }

--- a/modules/cloudsql/outputs.tf
+++ b/modules/cloudsql/outputs.tf
@@ -46,5 +46,5 @@ output "forseti-cloudsql-user" {
 
 output "forseti-cloudsql-password" {
   description = "CloudSQL password"
-  value       = var.cloudsql_password
+  value       = local.cloudsql_password
 }

--- a/modules/cloudsql/outputs.tf
+++ b/modules/cloudsql/outputs.tf
@@ -38,3 +38,13 @@ output "forseti-clodusql-db-port" {
   description = "CloudSQL database port"
   value       = "3306"
 }
+
+output "forseti-cloudsql-user" {
+  description = "CloudSQL user"
+  value       = var.cloudsql_db_user
+}
+
+output "forseti-cloudsql-password" {
+  description = "CloudSQL password"
+  value       = var.cloudsql_db_password
+}

--- a/modules/cloudsql/variables.tf
+++ b/modules/cloudsql/variables.tf
@@ -78,3 +78,13 @@ variable "cloudsql_user_host" {
   description = "The host the user can connect from. Can be an IP address or IP address range. Changing this forces a new resource to be created."
   default     = "%"
 }
+
+variable "cloudsql_db_user" {
+  description = "CloudSQL database user"
+  default     = "forseti_security_user"
+}
+
+variable "cloudsql_db_password" {
+  description = "CloudSQL database password"
+  default     = ""
+}

--- a/modules/cloudsql/variables.tf
+++ b/modules/cloudsql/variables.tf
@@ -79,12 +79,12 @@ variable "cloudsql_user_host" {
   default     = "%"
 }
 
-variable "cloudsql_db_user" {
-  description = "CloudSQL database user"
+variable "cloudsql_user" {
+  description = "CloudSQL user"
   default     = "forseti_security_user"
 }
 
-variable "cloudsql_db_password" {
-  description = "CloudSQL database password"
+variable "cloudsql_password" {
+  description = "CloudSQL password"
   default     = ""
 }

--- a/modules/on_gke/README.md
+++ b/modules/on_gke/README.md
@@ -43,14 +43,14 @@ This sub-module deploys Forseti on GKE.  In short, this deploys a server contain
 | cloudbilling\_period | The period of max calls for the Cloud Billing API (in seconds) | string | `"1.2"` | no |
 | cloudsql\_acl\_enabled | Cloud SQL scanner enabled. | bool | `"true"` | no |
 | cloudsql\_acl\_violations\_should\_notify | Notify for CloudSQL ACL violations | bool | `"true"` | no |
-| cloudsql\_user | CloudSQL user | string | `"forseti_security_user"` | no |
-| cloudsql\_password | CloudSQL password | string | `a randomized password` | no |
 | cloudsql\_db\_name | CloudSQL database name | string | `"forseti_security"` | no |
 | cloudsql\_disk\_size | The size of data disk, in GB. Size of a running instance cannot be reduced but can be increased. | string | `"25"` | no |
 | cloudsql\_net\_write\_timeout | See MySQL documentation: https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_net_write_timeout | string | `"240"` | no |
+| cloudsql\_password | CloudSQL password | string | `""` | no |
 | cloudsql\_private | Whether to enable private network and not to create public IP for CloudSQL Instance | bool | `"false"` | no |
 | cloudsql\_region | CloudSQL region | string | `"us-central1"` | no |
 | cloudsql\_type | CloudSQL Instance size | string | `"db-n1-standard-4"` | no |
+| cloudsql\_user | CloudSQL user | string | `"forseti_security_user"` | no |
 | cloudsql\_user\_host | The host the user can connect from.  Can be an IP address or IP address range. Changing this forces a new resource to be created. | string | `"%"` | no |
 | composite\_root\_resources | A list of root resources that Forseti will monitor. This supersedes the root_resource_id when set. | list(string) | `<list>` | no |
 | compute\_disable\_polling | Whether to disable polling for Compute API | bool | `"false"` | no |

--- a/modules/on_gke/README.md
+++ b/modules/on_gke/README.md
@@ -43,6 +43,8 @@ This sub-module deploys Forseti on GKE.  In short, this deploys a server contain
 | cloudbilling\_period | The period of max calls for the Cloud Billing API (in seconds) | string | `"1.2"` | no |
 | cloudsql\_acl\_enabled | Cloud SQL scanner enabled. | bool | `"true"` | no |
 | cloudsql\_acl\_violations\_should\_notify | Notify for CloudSQL ACL violations | bool | `"true"` | no |
+| cloudsql\_user | CloudSQL user | string | `"forseti_security_user"` | no |
+| cloudsql\_password | CloudSQL password | string | `a randomized password` | no |
 | cloudsql\_db\_name | CloudSQL database name | string | `"forseti_security"` | no |
 | cloudsql\_disk\_size | The size of data disk, in GB. Size of a running instance cannot be reduced but can be increased. | string | `"25"` | no |
 | cloudsql\_net\_write\_timeout | See MySQL documentation: https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_net_write_timeout | string | `"240"` | no |

--- a/modules/on_gke/main.tf
+++ b/modules/on_gke/main.tf
@@ -208,7 +208,7 @@ resource "helm_release" "forseti-security" {
     value = module.cloudsql.forseti-cloudsql-user
   }
 
-  set-sensitive {
+  set_sensitive {
     name  = "database.password"
     value = module.cloudsql.forseti-cloudsql-password
   }

--- a/modules/on_gke/main.tf
+++ b/modules/on_gke/main.tf
@@ -204,6 +204,16 @@ resource "helm_release" "forseti-security" {
   "google_service_account_iam_binding.forseti_client_workload_identity"]
 
   set {
+    name  = "database.username"
+    value = module.cloudsql.forseti-cloudsql-user
+  }
+
+  set-sensitive {
+    name  = "database.password"
+    value = module.cloudsql.forseti-cloudsql-password
+  }
+
+  set {
     name  = "server.cloudsqlConnection"
     value = module.cloudsql.forseti-cloudsql-connection-name
   }

--- a/modules/on_gke/variables.tf
+++ b/modules/on_gke/variables.tf
@@ -828,13 +828,13 @@ variable "cloudsql_user_host" {
   default     = "%"
 }
 
-variable "cloudsql_db_user" {
-  description = "CloudSQL database user"
+variable "cloudsql_user" {
+  description = "CloudSQL user"
   default     = "forseti_security_user"
 }
 
-variable "cloudsql_db_password" {
-  description = "CloudSQL database password"
+variable "cloudsql_password" {
+  description = "CloudSQL password"
   default     = ""
 }
 

--- a/modules/on_gke/variables.tf
+++ b/modules/on_gke/variables.tf
@@ -828,6 +828,16 @@ variable "cloudsql_user_host" {
   default     = "%"
 }
 
+variable "cloudsql_db_user" {
+  description = "CloudSQL database user"
+  default     = "forseti_security_user"
+}
+
+variable "cloudsql_db_password" {
+  description = "CloudSQL database password"
+  default     = ""
+}
+
 #-------------#
 # Helm config #
 #-------------#

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -105,6 +105,8 @@ data "template_file" "forseti_server_env" {
     cloudsql_db_port       = var.cloudsql_module.forseti-clodusql-db-port
     cloudsql_region        = var.cloudsql_module.forseti-cloudsql-region
     cloudsql_instance_name = var.cloudsql_module.forseti-cloudsql-instance-name
+    cloudsql_db_user       = var.cloudsql_module.forseti-cloudsql-user
+    cloudsql_db_password   = var.cloudsql_module.forseti-cloudsql-password
   }
 }
 

--- a/modules/server/templates/scripts/forseti-server/forseti_env.sh.tpl
+++ b/modules/server/templates/scripts/forseti-server/forseti_env.sh.tpl
@@ -1,3 +1,5 @@
 export SQL_PORT=${cloudsql_db_port}
 export SQL_INSTANCE_CONN_STRING=${project_id}:${cloudsql_region}:${cloudsql_instance_name}
 export FORSETI_DB_NAME=${cloudsql_db_name}
+export SQL_DB_USER=${cloudsql_db_user}
+export SQL_DB_PASSWORD=${cloudsql_db_password}

--- a/variables.tf
+++ b/variables.tf
@@ -850,6 +850,16 @@ variable "cloudsql_net_write_timeout" {
   default     = "240"
 }
 
+variable "cloudsql_db_user" {
+  description = "CloudSQL database user"
+  default     = "forseti_security_user"
+}
+
+variable "cloudsql_db_password" {
+  description = "CloudSQL database password"
+  default     = ""
+}
+
 #----------------#
 # Forseti bucket #
 #----------------#


### PR DESCRIPTION
As for KMS, I don't see any direct benefit on using that because if the user can ssh to the VM, they will be able to decrypt the encoded password anyway (due to elevated permission on the VM SA account).

Resolves: forseti-security/forseti-security#3217
Relates: forseti-security/forseti-security#3266