### PR TITLE
Adding manage_server_config_enabled variable 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Version 5.0.0 is a backwards-incompatible release. Please see the [upgrade instr
 - Cleaning up unused input variables. [#300]
 - Add ability to set net_write_timeout for CloudSQL [#299]
 - Update server config template to reflect CSCC notifier changes [#292]
+- Adding manage_server_config_enabled variable [#326]
 
 ## [v4.3.0] - 2019-10-03
 
@@ -289,6 +290,7 @@ Version 4.0.0 is a backwards-incompatible release. Please see the [upgrade instr
 [v4.3.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v4.2.1...v4.3.0
 [v5.0.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v4.3.0...v5.0.0
 
+[#326]: https://github.com/forseti-security/terraform-google-forseti/pull/326
 [#317]: https://github.com/forseti-security/terraform-google-forseti/pull/317
 [#309]: https://github.com/forseti-security/terraform-google-forseti/pull/309
 [#308]: https://github.com/forseti-security/terraform-google-forseti/pull/308

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ your environment.
 | logging\_period | The period of max calls for the Logging API (in seconds) | string | `"1.0"` | no |
 | mailjet\_enabled | Enable mailjet_rest library | bool | `"false"` | no |
 | manage\_rules\_enabled | A toggle to enable or disable the management of rules | bool | `"true"` | no |
+| manage\_server\_config\_enabled | A toggle to enable or disable the management of the server config. If the forseti_conf_server.yaml has been customized in GCS outside of Terraform, setting this to false will prevent Terraform from overwriting the configuration. | bool | `"true"` | no |
 | network | The VPC where the Forseti client and server will be created | string | `"default"` | no |
 | network\_project | The project containing the VPC and subnetwork where the Forseti client and server will be created | string | `""` | no |
 | org\_id | GCP Organization ID that Forseti will have purview over | string | `""` | no |

--- a/examples/install_simple/tutorial.md
+++ b/examples/install_simple/tutorial.md
@@ -18,7 +18,7 @@ This can either be a dedicated Forseti project or an existing DevSecOps project.
 
 You will need to activate a few APIs on this project for Forseti to function.
 
-Note: If this step is blocked by an error "Unable to enable required APIs", navigate to the APIs and Services page on the GCP console and manually enable the specified APIs. 
+Note: If this step is blocked by an error "Unable to enable required APIs", navigate to the APIs and Services page on the GCP console and manually enable the specified APIs.
 
 Alternatively, you can use the following `gcloud` commands:
 

--- a/helpers/cleanup.sh
+++ b/helpers/cleanup.sh
@@ -200,7 +200,7 @@ gcloud projects remove-iam-policy-binding "${PROJECT_ID}" \
 if [[ -n "$ON_GKE" ]]; then
   gke_roles=("roles/container.admin" "roles/compute.networkAdmin" "roles/resourcemanager.projectIamAdmin")
 
-  echo "Removing on-GKE related roles on project $PROJECT_ID..." 
+  echo "Removing on-GKE related roles on project $PROJECT_ID..."
   for gke_role in "${gke_roles[@]}"; do
     gcloud projects remove-iam-policy-binding "${PROJECT_ID}" \
         --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \

--- a/helpers/import.sh
+++ b/helpers/import.sh
@@ -46,7 +46,7 @@ Example of required Terraform configuration:
 
     module "forseti" {
       source = "terraform-google-modules/forseti/google"
-      version = "~> 4.2"
+      version = "~> 5.0"
 
       domain               = "example.com"
       project_id           = "forseti-235k"
@@ -62,8 +62,9 @@ Example of required Terraform configuration:
       client_instance_metadata = {
         enable-oslogin = "TRUE"
       }
-      enable_write         = true
-      manage_rules_enabled = false
+      enable_write                 = true
+      manage_rules_enabled         = false
+      manage_server_config_enabled = false
     }
 
 EOF

--- a/helpers/setup.sh
+++ b/helpers/setup.sh
@@ -193,7 +193,7 @@ fi
 if [[ -n "$ON_GKE" ]]; then
   gke_roles=("roles/container.admin" "roles/compute.networkAdmin" "roles/resourcemanager.projectIamAdmin")
 
-  echo "Granting on-GKE related roles on project $PROJECT_ID..." 
+  echo "Granting on-GKE related roles on project $PROJECT_ID..."
   for gke_role in "${gke_roles[@]}"; do
     gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
         --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \

--- a/main.tf
+++ b/main.tf
@@ -216,6 +216,7 @@ module "server_rules" {
 module "server_config" {
   source                                              = "./modules/server_config"
   composite_root_resources                            = var.composite_root_resources
+  manage_server_config_enabled                        = var.manage_server_config_enabled
   server_gcs_module                                   = module.server_gcs
   forseti_email_recipient                             = var.forseti_email_recipient
   forseti_email_sender                                = var.forseti_email_sender

--- a/modules/on_gke/README.md
+++ b/modules/on_gke/README.md
@@ -136,6 +136,7 @@ This sub-module deploys Forseti on GKE.  In short, this deploys a server contain
 | logging\_max\_calls | Maximum calls that can be made to Logging API | string | `"9"` | no |
 | logging\_period | The period of max calls for the Logging API (in seconds) | string | `"1.0"` | no |
 | manage\_rules\_enabled | A toggle to enable or disable the management of rules | bool | `"true"` | no |
+| manage\_server\_config\_enabled | A toggle to enable or disable the management of the server config. If the forseti_conf_server.yaml has been customized in GCS outside of Terraform, setting this to false will prevent Terraform from overwriting the configuration. | bool | `"true"` | no |
 | network | The VPC where the Forseti client and server will be created | string | `"default"` | no |
 | network\_policy | Apply pod network policies | bool | `"false"` | no |
 | network\_project | The project containing the VPC and subnetwork where the Forseti client and server will be created | string | `""` | no |

--- a/modules/on_gke/main.tf
+++ b/modules/on_gke/main.tf
@@ -87,26 +87,6 @@ resource "google_project_service" "main" {
 }
 
 //*****************************************
-//  Obtain Forseti Server Configuration
-//*****************************************
-
-data "google_storage_object_signed_url" "file_url" {
-  bucket      = module.server_gcs.forseti-server-storage-bucket
-  path        = "configs/forseti_conf_server.yaml"
-  content_md5 = module.server_config.forseti-server-config-md5
-}
-
-data "http" "server_config_contents" {
-  url = data.google_storage_object_signed_url.file_url.signed_url
-
-  request_headers = {
-    "Content-MD5" = module.server_config.forseti-server-config-md5
-  }
-
-  depends_on = ["data.google_storage_object_signed_url.file_url"]
-}
-
-//*****************************************
 //  Create Kubernetes Forseti Namespace
 //*****************************************
 
@@ -225,7 +205,7 @@ resource "helm_release" "forseti-security" {
 
   set_string {
     name  = "server.config.contents"
-    value = "${base64encode(data.http.server_config_contents.body)}"
+    value = "${base64encode(module.server_gcs.forseti-server-config)}"
   }
 
   set {

--- a/modules/on_gke/main.tf
+++ b/modules/on_gke/main.tf
@@ -205,7 +205,7 @@ resource "helm_release" "forseti-security" {
 
   set_string {
     name  = "server.config.contents"
-    value = "${base64encode(module.server_gcs.forseti-server-config)}"
+    value = "${base64encode(module.server_config.forseti-server-config)}"
   }
 
   set {

--- a/modules/on_gke/variables.tf
+++ b/modules/on_gke/variables.tf
@@ -477,6 +477,11 @@ variable "manage_rules_enabled" {
   default     = true
 }
 
+variable "manage_server_config_enabled" {
+  description = "A toggle to enable or disable the management of the server config. If the forseti_conf_server.yaml has been customized in GCS outside of Terraform, setting this to false will prevent Terraform from overwriting the configuration."
+  type        = bool
+  default     = true
+}
 
 variable "policy_library_repository_url" {
   description = "The git repository containing the policy-library."

--- a/modules/server_config/main.tf
+++ b/modules/server_config/main.tf
@@ -53,7 +53,7 @@ resource "null_resource" "missing_emails" {
 #-------------------#
 
 data "template_file" "forseti_server_config" {
-  count = var.manage_server_config_enabled ? 1 : 0
+  count    = var.manage_server_config_enabled ? 1 : 0
   template = local.server_conf
 
   # The variable casing and naming used here is used to match the
@@ -193,11 +193,11 @@ resource "google_storage_bucket_object" "forseti_server_config" {
 //*****************************************
 
 data "google_storage_object_signed_url" "file_url" {
-  bucket      = var.server_gcs_module.forseti-server-storage-bucket
-  path        = "configs/forseti_conf_server.yaml"
+  bucket = var.server_gcs_module.forseti-server-storage-bucket
+  path   = "configs/forseti_conf_server.yaml"
 }
 
 data "http" "server_config_contents" {
-  url = data.google_storage_object_signed_url.file_url.signed_url
+  url        = data.google_storage_object_signed_url.file_url.signed_url
   depends_on = ["data.google_storage_object_signed_url.file_url"]
 }

--- a/modules/server_config/outputs.tf
+++ b/modules/server_config/outputs.tf
@@ -16,10 +16,5 @@
 
 output "forseti-server-config" {
   description = "The rendered Forseti server configuration file"
-  value       = data.template_file.forseti_server_config.rendered
-}
-
-output "forseti-server-config-md5" {
-  description = "The Base64 encoded md5 hash for the server configuration file"
-  value       = google_storage_bucket_object.forseti_server_config.md5hash
+  value       = local.server_config_contents
 }

--- a/modules/server_config/variables.tf
+++ b/modules/server_config/variables.tf
@@ -23,6 +23,12 @@ variable "composite_root_resources" {
   default     = []
 }
 
+variable "manage_server_config_enabled" {
+  description = "A toggle to enable or disable the management of the server config. If the forseti_conf_server.yaml has been customized in GCS outside of Terraform, setting this to false will prevent Terraform from overwriting the configuration."
+  type        = bool
+  default     = true
+}
+
 variable "sendgrid_api_key" {
   description = "Sendgrid.com API key to enable email notifications"
   default     = ""

--- a/variables.tf
+++ b/variables.tf
@@ -505,6 +505,12 @@ variable "manage_rules_enabled" {
   default     = true
 }
 
+variable "manage_server_config_enabled" {
+  description = "A toggle to enable or disable the management of the server config. If the forseti_conf_server.yaml has been customized in GCS outside of Terraform, setting this to false will prevent Terraform from overwriting the configuration."
+  type        = bool
+  default     = true
+}
+
 variable "policy_library_home" {
   description = "The local policy library directory."
   default     = "$USER_HOME/policy-library"


### PR DESCRIPTION
**Significant Change:** The _manage_server_config_enabled_ variable, when set to false, will disable Terraform from writing a new forseti_conf_server.yaml file if one previously existed in GCS.

