### PR TITLE
Improve ReadMe and Tutorial

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,5 +95,4 @@ Run `make docker_test_lint`.
 [kitchen]: https://kitchen.ci/
 [make]: https://en.wikipedia.org/wiki/Make_(software)
 [shellcheck]: https://www.shellcheck.net/
-[terraform-docs]: https://github.com/segmentio/terraform-docs
 [terraform]: https://terraform.io/

--- a/README.md
+++ b/README.md
@@ -45,12 +45,11 @@ Utilizing a shared VPC via a host project is supported with the `-f` flag:
 ```
 
 ### Terraform Configuration
-Example configurations are included in the [examples](./examples/) directory. You can copy these examples or use your own custom configuration.
+Example configurations are included in the [examples](./examples/) directory. You can copy these examples or use the snippet below as a starting point to your own custom configuration.
 
-The default Forseti Server VM [machine type](https://cloud.google.com/compute/docs/machine-types) and Cloud SQL [machine type](https://cloud.google.com/sql/pricing#2nd-gen-pricing) have been set to `n1-standard-8` and `db-n1-standard-4`
-to account for larger GCP environments.
+The default Forseti Server VM [machine type](https://cloud.google.com/compute/docs/machine-types) and Cloud SQL [machine type](https://cloud.google.com/sql/pricing#2nd-gen-pricing) have been set to `n1-standard-8` and `db-n1-standard-4` to account for larger GCP environments. These can be changed by providing the `server_type` and `cloudsql_type` variables.
 
-Simple usage of the module within your own main.tf file is as follows:
+Create a file named `main.tf` in an empty directory and copy the contents below into the file.
 
 ```hcl
     module "forseti" {
@@ -61,11 +60,10 @@ Simple usage of the module within your own main.tf file is as follows:
       domain             = "yourdomain.com"
       project_id         = "my-forseti-project"
       org_id             = "2313934234"
-
-      server_type        = "n1-standard-2"
-      cloudsql_type      = "db-n1-standard-2"
     }
 ```
+
+Forseti provides many optional settings for users to customize for their environment and security requirements. View the list of [inputs](#inputs) to see all of the available options.
 
 ### Run Terraform
 Forseti is ready to be installed! First you will need to initialize Terraform to download any of the module dependencies.

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 The Forseti Terraform module is the only supported method of installing [Forseti Security](https://forsetisecurity.org/). The default infrastructure for Forseti is Google Compute Engine. This module also supports installing Forseti on Google Kubernetes Engine (GKE), and at some point in the future will become the default. For more information on installing Forseti on GKE, please see the [detailed guide on the Forseti Security website](https://forsetisecurity.org/docs/latest/setup/forseti-on-gke.html).
 
 ## Google Cloud Shell Walkthrough
-A Google Cloud Shell Walkthrough has been setup to make it easy for users who are new to Forseti and Terraform. This walkthrough provides a set of instructions to get a default installation of Forseti setup that can be used as a production environment.
+A Google Cloud Shell Walkthrough has been setup to make it easy for users who are new to Forseti and Terraform. This walkthrough provides a set of instructions to get a default installation of Forseti setup that can be used in a production environment.
 
 If you are familiar with Terraform and would like to run Terraform from a different machine, you can skip this walkthrough and move onto the [How to Deploy](#how-to-deploy) section.
 
-[![Open in Google Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fforseti-security%2Fterraform-google-forseti.git&cloudshell_git_branch=feature/cloud-shell-docs&cloudshell_working_dir=examples/install_simple&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&cloudshell_tutorial=.%2Ftutorial.md)
+[![Open in Google Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fforseti-security%2Fterraform-google-forseti.git&cloudshell_git_branch=module-release-5.0.0&cloudshell_working_dir=examples/install_simple&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&cloudshell_tutorial=.%2Ftutorial.md)
 
 ## How to Deploy
 In order to run this module you will need to be authenticated as a user that has access to the project and can create/authorize service accounts at both the organization and project levels. To login to GCP from a shell:

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Now that Forseti has been deployed, there are additional steps that you can foll
 This section describes in detail the requirements necessary to deploy Forseti. The setup helper script automates the service account creation and enabling the APIs for you. Read through this section if you are not using the setup script or want to understand these details.
 
 1. Install Terraform.
-2. A GCP project to deploy Forseti into. The [Google Project Factory Terraform][terraform-google-project-factory] module can be used to provision the project with the required APIs enabled, along with a Shared VPC connection.
+2. A GCP project to deploy Forseti into. The [Google Project Factory Terraform][https://github.com/terraform-google-modules/terraform-google-project-factory] module can be used to provision the project with the required APIs enabled, along with a Shared VPC connection.
 3. The Service Account used to execute this module has the right permissions.
 4. Enable the required GCP APIs to allow the Terraform module to deploy Forseti.
 
@@ -122,7 +122,7 @@ This section describes in detail the requirements necessary to deploy Forseti. T
 - [Terraform Provider Templates](https://www.terraform.io/docs/providers/template/index.html) 2.0
 
 ### Service Account
-In order to execute this module you must have a Service Account with the following roles assigned. There is a helpful setup script documented below which can automatically create this account for you.
+In order to execute this module you must have a Service Account with the following IAM roles assigned.
 
 #### IAM Roles
 For this module to work, you need the following roles enabled on the Service Account.
@@ -337,15 +337,15 @@ For this module to work, you need the following APIs enabled on the Forseti proj
 ## File structure
 The project has the following folders and files:
 
-- [/build](./build/): Google Cloud Build configuration
-- [/docs](./docs/): Additional documentation
-- [/examples](./examples/): examples for using this module
-- [/helpers](./helpers/): Helper scripts
-- [/modules](./modules/): Private and sub-modules
-- [/test](./test/): All integration tests are located here
-- [/CHANGELOG.md](./CHANGELOG.md): A list of changes made for each release
-- [/CONTRIBUTING.md](./CONTRIBUTING.md): Information on how to contribute to this project
-- [/LICENSE](./LICENSE): License terms and conditions
-- [/main.tf](./main.tf): Main Terraform configuration file for this module, contains all the resources to install Forseti
-- [/README.md](./README.md): This readme file
-- [/variables.tf](./variables.tf): All the variables for the module
+- [build/](./build/): Google Cloud Build configuration
+- [docs/](./docs/): Additional documentation
+- [examples/](./examples/): examples for using this module
+- [helpers/](./helpers/): Helper scripts
+- [modules/](./modules/): Private and sub-modules
+- [test/](./test/): All integration tests are located here
+- [CHANGELOG.md](./CHANGELOG.md): A list of changes made for each release
+- [CONTRIBUTING.md](./CONTRIBUTING.md): Information on how to contribute to this project
+- [LICENSE](./LICENSE): License terms and conditions
+- [main.tf](./main.tf): Main Terraform configuration file for this module, contains all the resources to install Forseti
+- [README.md](./README.md): This readme file
+- [variables.tf](./variables.tf): All the variables for the module

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Now that Forseti has been deployed, there are additional steps that you can foll
 This section describes in detail the requirements necessary to deploy Forseti. The setup helper script automates the service account creation and enabling the APIs for you. Read through this section if you are not using the setup script or want to understand these details.
 
 1. Install Terraform.
-2. A GCP project to deploy Forseti into. The [Google Project Factory Terraform][https://github.com/terraform-google-modules/terraform-google-project-factory] module can be used to provision the project with the required APIs enabled, along with a Shared VPC connection.
+2. A GCP project to deploy Forseti into. The [Google Project Factory Terraform](https://github.com/terraform-google-modules/terraform-google-project-factory) module can be used to provision the project with the required APIs enabled, along with a Shared VPC connection.
 3. The Service Account used to execute this module has the right permissions.
 4. Enable the required GCP APIs to allow the Terraform module to deploy Forseti.
 

--- a/README.md
+++ b/README.md
@@ -3,15 +3,14 @@
 The Forseti Terraform module is the only supported method of installing [Forseti Security](https://forsetisecurity.org/). The default infrastructure for Forseti is Google Compute Engine. This module also supports installing Forseti on Google Kubernetes Engine (GKE), and at some point in the future will become the default. For more information on installing Forseti on GKE, please see the [detailed guide on the Forseti Security website](https://forsetisecurity.org/docs/latest/setup/forseti-on-gke.html).
 
 ## Google Cloud Shell Walkthrough
-A Google Cloud Shell Walkthrough has been setup to make it easy for users who are new to Forseti and Terraform. This Walkthrough provides a set of instructions to get a default installation of Forseti setup that can be used as a production environment.
+A Google Cloud Shell Walkthrough has been setup to make it easy for users who are new to Forseti and Terraform. This walkthrough provides a set of instructions to get a default installation of Forseti setup that can be used as a production environment.
 
-If you are familiar with Terraform and would like to run Terraform from a different machine, you can skip this Walkthrough and move onto the [How to Deploy](#how-to-deploy) section.
+If you are familiar with Terraform and would like to run Terraform from a different machine, you can skip this walkthrough and move onto the [How to Deploy](#how-to-deploy) section.
 
-[![Open Google Cloud Shell Walkthrough](https://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fforseti-security%2Fterraform-google-forseti.git&cloudshell_git_branch=feature/cloud-shell-docs&cloudshell_working_dir=examples/install_simple&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&cloudshell_tutorial=.%2Ftutorial.md)
+[![Open in Google Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fforseti-security%2Fterraform-google-forseti.git&cloudshell_git_branch=feature/cloud-shell-docs&cloudshell_working_dir=examples/install_simple&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&cloudshell_tutorial=.%2Ftutorial.md)
 
 ## How to Deploy
-In order to run this module you will need to be authenticated as a user that can create/authorize service accounts at
-both the organization and project levels. To login to GCP from a command line shell:
+In order to run this module you will need to be authenticated as a user that has access to the project and can create/authorize service accounts at both the organization and project levels. To login to GCP from a shell:
 
 ```bash
 gcloud auth login
@@ -28,7 +27,7 @@ The Service Account and required APIs can be setup automatically with a provided
 ```
 
 This will create a service account called `cloud-foundation-forseti-<suffix>`,
-give it the proper roles, and download the service account credentials to
+assign it the proper roles, and download the service account credentials to
 `${PWD}/credentials.json`.
 
 If you are using the real time policy enforcer, you will need to generate a

--- a/examples/install_simple/terraform.tfvars
+++ b/examples/install_simple/terraform.tfvars
@@ -1,8 +1,8 @@
 project_id = "my-project-id"
 org_id     = "11111111"
 domain     = "mydomain.com"
-
 region          = "us-east4"
+
 network         = "default"
 subnetwork      = "default"
 network_project = ""

--- a/examples/install_simple/tutorial.md
+++ b/examples/install_simple/tutorial.md
@@ -5,7 +5,7 @@
 
 This walkthrough explains how to deploy [Forseti](https://forsetisecurity.org/about/) in a GCP project using Terraform.
 
-### Authentication
+## Authentication
 In order to run this module you will need to be authenticated as a user that has access to the project and can create/authorize service accounts at both the organization and project levels. You can login as this user with Chrome or by using gcloud from a shell:
 
  ```bash
@@ -22,10 +22,16 @@ This can be a dedicated Forseti project or an existing DevSecOps project.
 ## Prerequisites
 In order to execute this module a temporary Service Account will be created with the roles required. A few GCP APIs also need to be enabled. These steps have been automated with a setup script. The [IAM Roles](/README.md#iam-roles) given to the Service Account and the [APIs](/README.md#apis) that will be enabled are listed on the README.
 
-You can run this setup script by providing the Organization ID and Project ID:
+Set the project ID for future gcloud commands:
 
 ```bash
-. ../../helpers/setup.sh -o ORG_ID -p {{project_id}}
+gcloud config set project {{project_id}}
+```
+
+Run the setup script by providing the Organization ID:
+
+```bash
+. ../../helpers/setup.sh -p {{project_id}} -o ORG_ID
 ```
 
 ## Forseti Terraform module configuration
@@ -143,22 +149,22 @@ If you encounter any errors, check the configuration and permissions; then run `
 ## Save Terraform State
 Congratulations, you have now deployed Forseti!
 
-As a final step, you will want to save the Terraform configuration so it can be used to upgrade Forseti in the future. This can be saved to a Google Cloud Storage (GCS) bucket.
+You will want to save the Terraform configuration so it can be used to upgrade Forseti in the future. This can be saved to a Google Cloud Storage (GCS) bucket.
 
 ### Create Terraform state bucket
 Create a Google Cloud Storage bucket to [store your Terraform state](https://www.terraform.io/docs/state/).
 
 ```bash
-gsutil mb gs://{{project_id}}-tfstate
+gsutil mb -p {{project_id}} gs://{{project_id}}-tfstate
 ```
 
 ### Upload state configuration
 Open <walkthrough-editor-open-file filePath="terraform-google-forseti/examples/install_simple/backend.tf">backend.tf</walkthrough-editor-open-file> and uncomment the contents.
 
-On line 3, update the <walkthrough-editor-select-regex
+Update the <walkthrough-editor-select-regex
   filePath="terraform-google-forseti/examples/install_simple/backend.tf"
   regex="my-project">project ID</walkthrough-editor-select-regex>
-project ID to match your project ID (`{{project_id}}`).
+in the bucket variable to match your project ID (`{{project_id}}`).
 
 Run the Terraform init command to upload the state to the GCS bucket:
 
@@ -169,7 +175,7 @@ terraform init
 At the prompt, type `yes`.
 
 ## Save Terraform Configuration
-As a best practice, you should save your Terraform configuration to source control. This can be done using Cloud Source Repositories.
+As a best practice, you should save the Terraform configuration to source control. This can be done using Cloud Source Repositories. If you choose to perform this step, the Cloud Source Repositories API will need to be enabled.
 
 ### Create a repo
 ```bash
@@ -181,6 +187,15 @@ gcloud source repos create terraform-forseti
 git init
 ```
 
+### Configure the Git user email and name
+```
+git config --global user.email "{YOUR_EMAIL_ADDRESS}"
+```
+
+```
+git config --global user.name "{YOUR_NAME}"
+```
+
 ### Add and commit your files
 
 ```bash
@@ -190,8 +205,6 @@ git add -A
 ```bash
 git commit -m "Initial commit"
 ```
-
-You may be prompted to configure your identity for Git. If you are, follow the provided commands to do so and run commit again.
 
 ### Push your configuration
 ```bash

--- a/examples/install_simple/tutorial.md
+++ b/examples/install_simple/tutorial.md
@@ -1,48 +1,35 @@
 # Deploy Forseti
 
 ## Introduction
-
 <walkthrough-tutorial-duration duration="10"></walkthrough-tutorial-duration>
 
-This tutorial explains how to set up [Forseti](https://forsetisecurity.org/about/) in a GCP project using Cloud Shell.
+This walkthrough explains how to deploy [Forseti](https://forsetisecurity.org/about/) in a GCP project using Terraform.
 
-## Choose Project
-
-<walkthrough-project-billing-setup billing="true"></walkthrough-project-billing-setup>
-
-First, select a project to install Forseti in.
-
-This can either be a dedicated Forseti project or an existing DevSecOps project.
-
- You must be logged in with a Google Account that has permission to access the Project. If you need to login as a different user, use gcloud to switch users:
+### Authentication
+In order to run this module you will need to be authenticated as a user that has access to the project and can create/authorize service accounts at both the organization and project levels. You can login as this user with Chrome or by using gcloud from a shell:
 
  ```bash
  gcloud auth login
 ```
 
-## Activate APIs
+## Select Project
+<walkthrough-project-billing-setup billing="true"></walkthrough-project-billing-setup>
 
-You will need to activate a few APIs on this project to allow the Terraform module to install Forseti.
+First, create a new Project or select an existing Project where Forseti will be deployed.
 
-__Note:__ If this step is blocked by an error "Unable to enable required APIs", navigate to [APIs and Services](https://pantheon.corp.google.com/apis/dashboard?project={{project_id}}) on the GCP console and manually enable the specified APIs.
+This can be a dedicated Forseti project or an existing DevSecOps project.
 
-Alternatively you can use the following gcloud commands:
+## Prerequisites
+In order to execute this module a temporary Service Account will be created with the roles required. A few GCP APIs also need to be enabled. These steps have been automated with a setup script. The [IAM Roles](/README.md#iam-roles) given to the Service Account and the [APIs](/README.md#apis) that will be enabled are listed on the README.
+
+You can run this setup script by providing the Organization ID and Project ID:
 
 ```bash
-gcloud config set project {{project_id}}
+. ../../helpers/setup.sh -o ORG_ID -p {{project_id}}
 ```
 
-```bash
-gcloud services enable cloudresourcemanager.googleapis.com compute.googleapis.com serviceusage.googleapis.com
-```
-
-<walkthrough-enable-apis apis=
-  "cloudresourcemanager.googleapis.com,
-  compute.googleapis.com,
-  serviceusage.googleapis.com"></walkthrough-enable-apis>
-
-## Configure Forseti
-There are a few required settings that you will need to update in the Forseti Terraform configuration <walkthrough-editor-open-file filePath="terraform-google-forseti/examples/install_simple/terraform.tfvars">terraform.tfvars</walkthrough-editor-open-file> file.
+## Forseti Terraform module configuration
+There are a few required settings that need to updated in the Forseti Terraform configuration <walkthrough-editor-open-file filePath="terraform-google-forseti/examples/install_simple/terraform.tfvars">terraform.tfvars</walkthrough-editor-open-file> file.
 
 ### Set project
 On line 1, update the <walkthrough-editor-select-regex
@@ -54,13 +41,13 @@ to match your chosen project (`{{project_id}}`).
 On line 2, update the <walkthrough-editor-select-regex
   filePath="terraform-google-forseti/examples/install_simple/terraform.tfvars"
   regex="11111111">organization ID</walkthrough-editor-select-regex>
-to match your organization ID, which can be found in the URL bar.
+to match your organization ID.
 
 ### Set domain
 On line 3, update the <walkthrough-editor-select-regex
   filePath="terraform-google-forseti/examples/install_simple/terraform.tfvars"
   regex="mydomain.com">domain</walkthrough-editor-select-regex>
-to match your company Cloud Identity domain, which can be found in the URL bar.
+to match your company Cloud Identity domain.
 
 ### Set region
 On line 4, update the <walkthrough-editor-select-regex
@@ -69,9 +56,9 @@ On line 4, update the <walkthrough-editor-select-regex
 you wish to deploy Forseti in.
 
 ### Set network (Optional)
-If you want to deploy Forseti onto a specific Network, you can configure the following settings. Otherwise, you can leave the defaults.
+If you want to deploy Forseti onto a specific Network, you can configure the following settings. Otherwise you can leave the defaults.
 
-__Note:__ By default Forseti will run on VMs with external IPs.**
+__Note:__ By default Forseti will run on GCE VMs with external IPs.**
 
 On line 6, update the <walkthrough-editor-select-regex
   filePath="terraform-google-forseti/examples/install_simple/terraform.tfvars"
@@ -94,9 +81,7 @@ If you are deploying on a Shared VPC, you need to set the <walkthrough-editor-se
 on line 8. Otherwise, you can leave this empty.
 
 ## Enable Optional Features
-There are additional settings which you can configure in the settings file to enable advanced Forseti functionality.
-
-If you don't need these features, you can skip these steps.
+Forseti provides many optional settings for users to customize for their environment and security requirements. The features below are recommended, but are not required.
 
 ### Configure G Suite
 On line 10, set the <walkthrough-editor-select-regex
@@ -107,11 +92,11 @@ Ask your G Suite Admin if you don’t know the super admin email.
 This is part of the [G Suite data collection](https://forsetisecurity.org/docs/latest/configure/inventory/gsuite.html). The following functionalities will not work without G Suite integration:
 
 - G Suite Groups and Users in Inventory
-- G Suite Groups Scanner and Groups Settings Scanner
-- Group expansion in Explain
+- G Suite Groups Scanners
+- G Suite Group expansion in Explain
 
 ### Configure email notifications
-Forseti can be configured to [send email notifications](https://forsetisecurity.org/docs/latest/configure/notifier/index.html#email-notifications).
+Forseti can be configured to [send email notifications](https://forsetisecurity.org/docs/latest/configure/notifier/index.html#email-notifications) when violations are found.
 
 To enable this, add a <walkthrough-editor-select-line
   filePath="terraform-google-forseti/examples/install_simple/terraform.tfvars"
@@ -134,32 +119,31 @@ and <walkthrough-editor-select-line
 settings.
 
 ## Deploy Forseti
-Now that you have updated your configuration settings, you are ready to install Forseti.
-
-This will be done using Terraform, which comes pre-installed with this Cloud Shell Walkthrough.
+Now that you have updated your configuration settings, Forseti is ready to be deployed.
 
 ### Initialize Terraform
-To download the Forseti module, you will need to initialize Terraform:
+Initialize Terraform to download the Forseti module:
+
 ```bash
 terraform init
 ```
 
 ### Apply Terraform
-You are now ready to deploy Forseti with Terraform by running the apply command:
+Deploy Forseti by running the Terraform apply command:
 
 ```bash
 terraform apply
 ```
 
-This can take a few minutes as all the necessary resources are provisioned.
+This can take a few minutes to provision all the necessary resources.
 
 ### Get Help
-If you encounter errors during installation, you can check your configuration and permissions, then run `terraform apply` again. If you need any help, please [Contact Us](https://forsetisecurity.org/docs/latest/use/get-help.html).
+If you encounter any errors, check the configuration and permissions; then run `terraform apply` again. If you need any help, please [Contact Us](https://forsetisecurity.org/docs/latest/use/get-help.html).
 
 ## Save Terraform State
-Congratulations, you have now installed Forseti!
+Congratulations, you have now deployed Forseti!
 
-As a final step, you will want to save your configuration so it can be used to upgrade Forseti in the future. This can be saved to a Google Cloud Storage (GCS) bucket.
+As a final step, you will want to save the Terraform configuration so it can be used to upgrade Forseti in the future. This can be saved to a Google Cloud Storage (GCS) bucket.
 
 ### Create Terraform state bucket
 Create a Google Cloud Storage bucket to [store your Terraform state](https://www.terraform.io/docs/state/).
@@ -168,7 +152,7 @@ Create a Google Cloud Storage bucket to [store your Terraform state](https://www
 gsutil mb gs://{{project_id}}-tfstate
 ```
 
-### Update state configuration
+### Upload state configuration
 Open <walkthrough-editor-open-file filePath="terraform-google-forseti/examples/install_simple/backend.tf">backend.tf</walkthrough-editor-open-file> and uncomment the contents.
 
 On line 3, update the <walkthrough-editor-select-regex
@@ -184,11 +168,8 @@ terraform init
 
 At the prompt, type `yes`.
 
-## Save configuration to git
+## Save Terraform Configuration
 As a best practice, you should save your Terraform configuration to source control. This can be done using Cloud Source Repositories.
-
-__Note:__ The Terraform state can contain sensitive information that should not be committed to source control. These state files will be ignored by the <walkthrough-editor-open-file
-filePath="terraform-google-forseti/examples/install_simple/.gitignore">.gitignore</walkthrough-editor-open-file> file.
 
 ### Create a repo
 ```bash
@@ -221,17 +202,25 @@ git remote add origin https://source.developers.google.com/p/{{project_id}}/r/te
 git push origin master
 ```
 
-## Installation Complete
+## Cleanup Service Account
+The last step is to cleanup the Service Account that was created for this walkthrough. This will deprovision and delete the service account, and then delete the credentials file. You will need to supply the Organization ID.
+
+Run the cleanup script:
+
+```bash
+../../helpers/cleanup.sh -p {{project_id}} -o ORG_ID
+```
+
+## Conclusion
+You have completed deploying Forseti and saving your configuration!
 
 <walkthrough-conclusion-trophy></walkthrough-conclusion-trophy>
-
-You have completed installing Forseti and saving your configuration!
 
 ### Periodic Scan
 Forseti is setup to run a periodic scan every 2 hours. This scan performs the various steps:
 - Collect an inventory of the GCP resources and G Suite Groups
 - Scan the inventory with the default set of [rules](https://github.com/forseti-security/terraform-google-forseti/tree/master/modules/rules/templates/rules)
-- Save the violation findings to a GCS bucket
+- Save the violation findings to a GCS bucket and send email notifications (if this was enabled)
 
 ### Configure Forseti
 There are [many options available](https://github.com/forseti-security/terraform-google-forseti#inputs) to configure Forseti to meet your security needs. This Walkthrough only exposes the required inputs along with a few commonly used options. You can start adding these additional inputs into this example's

--- a/examples/install_simple/tutorial.md
+++ b/examples/install_simple/tutorial.md
@@ -44,8 +44,6 @@ gcloud services enable cloudresourcemanager.googleapis.com compute.googleapis.co
 ## Configure Forseti
 There are a few required settings that you will need to update in the Forseti Terraform configuration <walkthrough-editor-open-file filePath="terraform-google-forseti/examples/install_simple/terraform.tfvars">terraform.tfvars</walkthrough-editor-open-file> file.
 
-__Note:__ Clicking the links below will open the Terraform configuration files and select the text that needs to be updated.
-
 ### Set project
 On line 1, update the <walkthrough-editor-select-regex
   filePath="terraform-google-forseti/examples/install_simple/terraform.tfvars"

--- a/examples/install_simple/tutorial.md
+++ b/examples/install_simple/tutorial.md
@@ -6,7 +6,7 @@
 This walkthrough explains how to deploy [Forseti](https://forsetisecurity.org/about/) in a GCP project using Terraform.
 
 ## Authentication
-In order to run this module you will need to be authenticated as a user that has access to the project and can create/authorize service accounts at both the organization and project levels. You can login as this user with Chrome or by using gcloud from a shell:
+In order to run this module you will need to be authenticated as a user that has access to the project and can create/authorize service accounts at both the organization and project levels. You can login as this user with Chrome or by using gcloud:
 
  ```bash
  gcloud auth login
@@ -35,7 +35,7 @@ Run the setup script by providing the Organization ID:
 ```
 
 ## Forseti Terraform module configuration
-There are a few required settings that need to updated in the Forseti Terraform configuration <walkthrough-editor-open-file filePath="terraform-google-forseti/examples/install_simple/terraform.tfvars">terraform.tfvars</walkthrough-editor-open-file> file.
+There are a few required settings that need to be updated in the Forseti Terraform configuration <walkthrough-editor-open-file filePath="terraform-google-forseti/examples/install_simple/terraform.tfvars">terraform.tfvars</walkthrough-editor-open-file> file.
 
 ### Set project
 On line 1, update the <walkthrough-editor-select-regex

--- a/helpers/cleanup.sh
+++ b/helpers/cleanup.sh
@@ -39,7 +39,7 @@ EOF
 
 PROJECT_ID=""
 ORG_ID=""
-SERVICE_ACCOUNT_NAME=""
+SERVICE_ACCOUNT_NAME=$FORSETI_SETUP_SERVICE_ACCOUNT_NAME
 WITH_ENFORCER=""
 HOST_PROJECT_ID=""
 ON_GKE=""
@@ -85,12 +85,6 @@ fi
 
 if [[ -z "$ORG_ID" ]]; then
   echo "ERROR: ORG_ID must be set."
-  show_help >&2
-  exit 1
-fi
-
-if [[ -z "$SERVICE_ACCOUNT_NAME" ]]; then
-  echo "ERROR: SERVICE_ACCOUNT_NAME must be set."
   show_help >&2
   exit 1
 fi
@@ -200,7 +194,7 @@ gcloud projects remove-iam-policy-binding "${PROJECT_ID}" \
 if [[ -n "$ON_GKE" ]]; then
   gke_roles=("roles/container.admin" "roles/compute.networkAdmin" "roles/resourcemanager.projectIamAdmin")
 
-  echo "Removing on-GKE related roles on project $PROJECT_ID..." 
+  echo "Removing on-GKE related roles on project $PROJECT_ID..."
   for gke_role in "${gke_roles[@]}"; do
     gcloud projects remove-iam-policy-binding "${PROJECT_ID}" \
         --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \

--- a/helpers/setup.sh
+++ b/helpers/setup.sh
@@ -100,6 +100,7 @@ SERVICE_ACCOUNT_NAME="cloud-foundation-forseti-${RANDOM}"
 SERVICE_ACCOUNT_EMAIL="${SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
 STAGING_DIR="${PWD}"
 KEY_FILE="${STAGING_DIR}/credentials.json"
+export FORSETI_SETUP_SERVICE_ACCOUNT_NAME="${SERVICE_ACCOUNT_NAME}"
 
 echo "Enabling services"
 gcloud services enable \
@@ -116,6 +117,8 @@ echo "Downloading key to credentials.json..."
 gcloud iam service-accounts keys create "${KEY_FILE}" \
     --iam-account "${SERVICE_ACCOUNT_EMAIL}" \
     --user-output-enabled false
+
+export GOOGLE_APPLICATION_CREDENTIALS="${KEY_FILE}"
 
 echo "Applying permissions for org $ORG_ID and project $PROJECT_ID..."
 
@@ -193,7 +196,7 @@ fi
 if [[ -n "$ON_GKE" ]]; then
   gke_roles=("roles/container.admin" "roles/compute.networkAdmin" "roles/resourcemanager.projectIamAdmin")
 
-  echo "Granting on-GKE related roles on project $PROJECT_ID..." 
+  echo "Granting on-GKE related roles on project $PROJECT_ID..."
   for gke_role in "${gke_roles[@]}"; do
     gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
         --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \


### PR DESCRIPTION
These updates are intended to make the ReadMe and Tutorial easier for users who are new to Terraform/Forseti to follow. I did some reorganization of the ReadMe so that you don't have to scroll through all of the inputs to read about the requirements and the manual (non-tutorial) deploy instructions. I included some minor changes to the setup/cleanup scripts to remove some manual steps the users would need to do.

Fixes #322 and #323.