### PR TITLE
Adding variables to end_to_end for test-ability

### DIFF
--- a/examples/on_gke_end_to_end/README.md
+++ b/examples/on_gke_end_to_end/README.md
@@ -72,8 +72,8 @@ This script will also activate necessary APIs required for Terraform to deploy F
 | gsuite\_admin\_email | G-Suite administrator email address to manage your Forseti installation | string | n/a | yes |
 | helm\_repository\_url | The Helm repository containing the 'forseti-security' Helm charts | string | `"https://forseti-security-charts.storage.googleapis.com/release/"` | no |
 | k8s\_forseti\_namespace | The Kubernetes namespace in which to deploy Forseti. | string | `"forseti"` | no |
-| k8s\_forseti\_orchestrator\_image\_tag | The tag for the container image for the Forseti orchestrator | string | `"v2.22.0"` | no |
-| k8s\_forseti\_server\_image\_tag | The tag for the container image for the Forseti server | string | `"v2.22.0"` | no |
+| k8s\_forseti\_orchestrator\_image\_tag | The tag for the container image for the Forseti orchestrator | string | `"v2.23.0"` | no |
+| k8s\_forseti\_server\_image\_tag | The tag for the container image for the Forseti server | string | `"v2.23.0"` | no |
 | k8s\_tiller\_sa\_name | The Kubernetes Service Account used by Tiller | string | `"tiller"` | no |
 | network | The name of the VPC being created | string | `"forseti-gke-network"` | no |
 | network\_description | An optional description of the network. The resource must be recreated to modify this field. | string | `""` | no |

--- a/examples/on_gke_end_to_end/README.md
+++ b/examples/on_gke_end_to_end/README.md
@@ -72,6 +72,8 @@ This script will also activate necessary APIs required for Terraform to deploy F
 | gsuite\_admin\_email | G-Suite administrator email address to manage your Forseti installation | string | n/a | yes |
 | helm\_repository\_url | The Helm repository containing the 'forseti-security' Helm charts | string | `"https://forseti-security-charts.storage.googleapis.com/release/"` | no |
 | k8s\_forseti\_namespace | The Kubernetes namespace in which to deploy Forseti. | string | `"forseti"` | no |
+| k8s\_forseti\_orchestrator\_image\_tag | The tag for the container image for the Forseti orchestrator | string | `"v2.22.0"` | no |
+| k8s\_forseti\_server\_image\_tag | The tag for the container image for the Forseti server | string | `"v2.22.0"` | no |
 | k8s\_tiller\_sa\_name | The Kubernetes Service Account used by Tiller | string | `"tiller"` | no |
 | network | The name of the VPC being created | string | `"forseti-gke-network"` | no |
 | network\_description | An optional description of the network. The resource must be recreated to modify this field. | string | `""` | no |

--- a/examples/on_gke_end_to_end/main.tf
+++ b/examples/on_gke_end_to_end/main.tf
@@ -198,11 +198,13 @@ module "forseti" {
   cscc_source_id          = var.cscc_source_id
 
 
-  config_validator_enabled         = var.config_validator_enabled
-  git_sync_private_ssh_key         = local.git_sync_private_ssh_key
-  k8s_forseti_server_ingress_cidr  = module.vpc.subnets_ips[0]
-  helm_repository_url              = var.helm_repository_url
-  policy_library_repository_url    = var.policy_library_repository_url
-  policy_library_repository_branch = var.policy_library_repository_branch
-  server_log_level                 = var.server_log_level
+  config_validator_enabled           = var.config_validator_enabled
+  git_sync_private_ssh_key           = local.git_sync_private_ssh_key
+  k8s_forseti_server_ingress_cidr    = module.vpc.subnets_ips[0]
+  k8s_forseti_server_image_tag       = var.k8s_forseti_server_image_tag
+  k8s_forseti_orchestrator_image_tag = var.k8s_forseti_orchestrator_image_tag
+  helm_repository_url                = var.helm_repository_url
+  policy_library_repository_url      = var.policy_library_repository_url
+  policy_library_repository_branch   = var.policy_library_repository_branch
+  server_log_level                   = var.server_log_level
 }

--- a/examples/on_gke_end_to_end/variables.tf
+++ b/examples/on_gke_end_to_end/variables.tf
@@ -109,6 +109,16 @@ variable "k8s_tiller_sa_name" {
   default     = "tiller"
 }
 
+variable "k8s_forseti_orchestrator_image_tag" {
+  description = "The tag for the container image for the Forseti orchestrator"
+  default     = "v2.22.0"
+}
+
+variable "k8s_forseti_server_image_tag" {
+  description = "The tag for the container image for the Forseti server"
+  default     = "v2.22.0"
+}
+
 variable "network" {
   description = "The name of the VPC being created"
   default     = "forseti-gke-network"

--- a/examples/on_gke_end_to_end/variables.tf
+++ b/examples/on_gke_end_to_end/variables.tf
@@ -111,12 +111,12 @@ variable "k8s_tiller_sa_name" {
 
 variable "k8s_forseti_orchestrator_image_tag" {
   description = "The tag for the container image for the Forseti orchestrator"
-  default     = "v2.22.0"
+  default     = "v2.23.0"
 }
 
 variable "k8s_forseti_server_image_tag" {
   description = "The tag for the container image for the Forseti server"
-  default     = "v2.22.0"
+  default     = "v2.23.0"
 }
 
 variable "network" {


### PR DESCRIPTION
Our release test frame work necessitates both:

* k8s_forseti_orchestrator_image_tag
* k8s_forseti_server_image_tag

be present in the _on_gke_end_to_end_ example.