### PR TITLE
Updated main.tf to pass the region to the CloudSQL region.

### DIFF
--- a/examples/install_simple/main.tf
+++ b/examples/install_simple/main.tf
@@ -15,29 +15,30 @@
  */
 
 module "forseti-install-simple" {
-  source  = "terraform-google-modules/forseti/google"
-  version = "~> 5.0.0"
+  source                   = "terraform-google-modules/forseti/google"
+  version                  = "~> 5.0.0"
 
-  project_id = var.project_id
-  org_id     = var.org_id
-  domain     = var.domain
+  project_id               = var.project_id
+  org_id                   = var.org_id
+  domain                   = var.domain
 
-  server_region = var.region
-  client_region = var.region
-  network       = var.network
-  subnetwork    = var.subnetwork
+  server_region            = var.region
+  client_region            = var.region
+  cloudsql_region          = var.region
+  network                  = var.network
+  subnetwork               = var.subnetwork
 
-  gsuite_admin_email      = var.gsuite_admin_email
-  sendgrid_api_key        = var.sendgrid_api_key
-  forseti_email_sender    = var.forseti_email_sender
-  forseti_email_recipient = var.forseti_email_recipient
+  gsuite_admin_email       = var.gsuite_admin_email
+  sendgrid_api_key         = var.sendgrid_api_key
+  forseti_email_sender     = var.forseti_email_sender
+  forseti_email_recipient  = var.forseti_email_recipient
 
   client_instance_metadata = var.instance_metadata
   server_instance_metadata = var.instance_metadata
 
-  client_tags = var.instance_tags
-  server_tags = var.instance_tags
+  client_tags              = var.instance_tags
+  server_tags              = var.instance_tags
 
-  client_private = var.private
-  server_private = var.private
+  client_private           = var.private
+  server_private           = var.private
 }

--- a/examples/install_simple/variables.tf
+++ b/examples/install_simple/variables.tf
@@ -64,7 +64,7 @@ variable "forseti_email_recipient" {
 }
 
 variable "region" {
-  description = "GCP region where Forseti will be deployed"
+  description = "The region where the Forseti GCE Instance VMs and CloudSQL Instances will be deployed"
 }
 
 variable "network" {


### PR DESCRIPTION
The install simple example will now deploy the GCE Instance VMs and CloudSQL instances in the same region. I performed a test using us-west2 and verified these resources all got deployed there.

Fixes #334