### PR TITLE
Changed master branch to module-release-v5.0.0

### DIFF
--- a/examples/migrate_forseti/tutorial.md
+++ b/examples/migrate_forseti/tutorial.md
@@ -188,10 +188,10 @@ to your <walkthrough-editor-select-regex
   regex="Add any Forseti Server Configuration Variables Here">main.tf</walkthrough-editor-select-regex>.
 
 ## Obtain and Run the Import Script
-This [import script](https://github.com/forseti-security/terraform-google-forseti/blob/module-release-v5.0.0/helpers/import.sh) will import the Forseti GCP resources into a local state file.
+This [import script](https://github.com/forseti-security/terraform-google-forseti/blob/module-release-5.0.0/helpers/import.sh) will import the Forseti GCP resources into a local state file.
 
 ```sh
-curl --location --remote-name https://raw.githubusercontent.com/forseti-security/terraform-google-forseti/module-release-v5.0.0/helpers/import.sh
+curl --location --remote-name https://raw.githubusercontent.com/forseti-security/terraform-google-forseti/module-release-5.0.0/helpers/import.sh
 chmod +x import.sh
 ./import.sh -h
 ```

--- a/examples/migrate_forseti/tutorial.md
+++ b/examples/migrate_forseti/tutorial.md
@@ -188,10 +188,10 @@ to your <walkthrough-editor-select-regex
   regex="Add any Forseti Server Configuration Variables Here">main.tf</walkthrough-editor-select-regex>.
 
 ## Obtain and Run the Import Script
-This [import script](https://github.com/forseti-security/terraform-google-forseti/blob/master/helpers/import.sh) will import the Forseti GCP resources into a local state file.
+This [import script](https://github.com/forseti-security/terraform-google-forseti/blob/module-release-v5.0.0/helpers/import.sh) will import the Forseti GCP resources into a local state file.
 
 ```sh
-curl --location --remote-name https://raw.githubusercontent.com/forseti-security/terraform-google-forseti/master/helpers/import.sh
+curl --location --remote-name https://raw.githubusercontent.com/forseti-security/terraform-google-forseti/module-release-v5.0.0/helpers/import.sh
 chmod +x import.sh
 ./import.sh -h
 ```

--- a/examples/upgrade_forseti_with_v5.0/tutorial.md
+++ b/examples/upgrade_forseti_with_v5.0/tutorial.md
@@ -118,10 +118,10 @@ Add the following clause to the bottom of your main.tf.
 
 ## Obtain and Run the Import Script
 ### Obtain the Import Script
-This [import script](https://github.com/forseti-security/terraform-google-forseti/blob/master/helpers/import.sh) will import the Forseti GCP resources into a local state file.
+This [import script](https://github.com/forseti-security/terraform-google-forseti/blob/module-release-v5.0.0/helpers/import.sh) will import the Forseti GCP resources into a local state file.
 
 ```sh
-curl --location --remote-name https://raw.githubusercontent.com/forseti-security/terraform-google-forseti/master/helpers/import.sh
+curl --location --remote-name https://raw.githubusercontent.com/forseti-security/terraform-google-forseti/module-release-v5.0.0/helpers/import.sh
 chmod +x import.sh
 ./import.sh -h
 ```

--- a/examples/upgrade_forseti_with_v5.0/tutorial.md
+++ b/examples/upgrade_forseti_with_v5.0/tutorial.md
@@ -118,10 +118,10 @@ Add the following clause to the bottom of your main.tf.
 
 ## Obtain and Run the Import Script
 ### Obtain the Import Script
-This [import script](https://github.com/forseti-security/terraform-google-forseti/blob/module-release-v5.0.0/helpers/import.sh) will import the Forseti GCP resources into a local state file.
+This [import script](https://github.com/forseti-security/terraform-google-forseti/blob/module-release-5.0.0/helpers/import.sh) will import the Forseti GCP resources into a local state file.
 
 ```sh
-curl --location --remote-name https://raw.githubusercontent.com/forseti-security/terraform-google-forseti/module-release-v5.0.0/helpers/import.sh
+curl --location --remote-name https://raw.githubusercontent.com/forseti-security/terraform-google-forseti/module-release-5.0.0/helpers/import.sh
 chmod +x import.sh
 ./import.sh -h
 ```


### PR DESCRIPTION
This fixes links in the migrate and uprade tutorials.  Was _master_ and is now _module-release-5.0.0_