### PR TITLE
Support the case where the user is syncing from GCS

### DIFF
--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -55,6 +55,8 @@ locals {
   network_interface = local.network_interface_base[var.server_private ? "private" : "public"]
 
   forseti_run_frequency = var.forseti_run_frequency == null ? "${random_integer.random_minute.result} */2 * * *" : var.forseti_run_frequency
+
+  git_sync_public_ssh_key = length(tls_private_key.policy_library_sync_ssh) == 1 ? tls_private_key.policy_library_sync_ssh[0].public_key_openssh : ""
 }
 
 #-------------------#

--- a/modules/server/outputs.tf
+++ b/modules/server/outputs.tf
@@ -16,7 +16,7 @@
 
 output "forseti-server-git-public-key-openssh" {
   description = "The public OpenSSH key generated to allow the Forseti Server to clone the policy library repository."
-  value       = tls_private_key.policy_library_sync_ssh[0].public_key_openssh
+  value       = local.git_sync_public_ssh_key
 }
 
 output "forseti-server-vm-ip" {


### PR DESCRIPTION
With Terraform version `0.12.12`, if a user sets
```
config_validator = true
policy_library_sync_enabled  = false
```
They will encounter an error in the output the public OpenSSH key not being generated.