### PR TITLE
Update GKE end-to-end example for machine type and disk type

### DIFF
--- a/examples/on_gke_end_to_end/main.tf
+++ b/examples/on_gke_end_to_end/main.tf
@@ -118,11 +118,11 @@ module "gke" {
 
   node_pools = [{
     name               = "default-node-pool"
-    machine_type       = "n1-standard-2"
+    machine_type       = var.default_node_pool_machine_type
     min_count          = 1
     max_count          = 1
-    disk_size_gb       = 100
-    disk_type          = "pd-standard"
+    disk_size_gb       = var.default_node_pool_disk_size
+    disk_type          = var.default_node_pool_disk_type
     image_type         = "COS"
     auto_repair        = true
     auto_upgrade       = false

--- a/examples/on_gke_end_to_end/variables.tf
+++ b/examples/on_gke_end_to_end/variables.tf
@@ -31,6 +31,21 @@ variable "cscc_source_id" {
   default     = ""
 }
 
+variable "default_node_pool_disk_size" {
+  description = "Default Node Pool disk size"
+  default     = 100
+}
+
+variable "default_node_pool_disk_type" {
+  description = "Default Node Pool disk type"
+  default     = "pd-ssd"
+}
+
+variable "default_node_pool_machine_type" {
+  description = "Default Node Pool machine type"
+  default     = "n1-standard-8"
+}
+
 variable "domain" {
   description = "The domain associated with the GCP Organization ID"
 }


### PR DESCRIPTION
Updated the On GKE end-to-end example to have the same machine type and disk type as the defaults for GCE. Moved these variables out of main.tf into the variables.tf file.

Fixes #368 