### PR TITLE
Update test fixtures to use master branch of Forseti

### DIFF
--- a/examples/shared_vpc/main.tf
+++ b/examples/shared_vpc/main.tf
@@ -53,4 +53,5 @@ module "forseti" {
   server_instance_metadata = var.instance_metadata
   client_private           = "true"
   server_private           = "true"
+  forseti_version          = var.forseti_version
 }

--- a/examples/shared_vpc/variables.tf
+++ b/examples/shared_vpc/variables.tf
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+variable "forseti_version" {
+  description = "The version of Forseti to install"
+  default     = "v2.23.0"
+}
+
 variable "network_project" {
   description = "ID of the project that will have shared VPC"
 }
@@ -52,4 +57,3 @@ variable "instance_metadata" {
   type        = map(string)
   default     = {}
 }
-

--- a/examples/simple_example/main.tf
+++ b/examples/simple_example/main.tf
@@ -55,5 +55,5 @@ module "forseti-install-simple" {
   sendgrid_api_key         = var.sendgrid_api_key
   forseti_email_sender     = var.forseti_email_sender
   forseti_email_recipient  = var.forseti_email_recipient
+  forseti_version          = var.forseti_version
 }
-

--- a/examples/simple_example/variables.tf
+++ b/examples/simple_example/variables.tf
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+variable "forseti_version" {
+  description = "The version of Forseti to install"
+  default     = "v2.23.0"
+}
+
 variable "gsuite_admin_email" {
   description = "The email of a GSuite super admin, used for pulling user directory information *and* sending notifications."
 }

--- a/test/fixtures/shared_vpc/main.tf
+++ b/test/fixtures/shared_vpc/main.tf
@@ -54,6 +54,7 @@ module "forseti-shared-vpc" {
   network_project    = var.network_project
   org_id             = var.org_id
   domain             = var.domain
+  forseti_version    = var.forseti_version
 
   instance_metadata = {
     sshKeys = "ubuntu:${tls_private_key.main.public_key_openssh}"

--- a/test/fixtures/shared_vpc/variables.tf
+++ b/test/fixtures/shared_vpc/variables.tf
@@ -14,33 +14,13 @@
  * limitations under the License.
  */
 
-variable "network_project" {
-  description = "ID of the project that will have shared VPC"
-}
-
-variable "project_id" {
-  description = "ID of the project that will have forseti server"
-}
-
-variable "org_id" {
-  description = "Organization ID"
-}
-
 variable "domain" {
   description = "Organization domain"
 }
 
-variable "network" {
-  description = "Name of the shared VPC"
-}
-
-variable "subnetwork" {
-  description = "Name of the subnetwork where forseti will be deployed"
-}
-
-variable "region" {
-  description = "Region where forseti subnetwork will be deployed"
-  default     = "us-central1"
+variable "forseti_version" {
+  description = "The version of Forseti to install"
+  default     = "master"
 }
 
 variable "gsuite_admin_email" {
@@ -53,3 +33,27 @@ variable "instance_metadata" {
   default     = {}
 }
 
+variable "network" {
+  description = "Name of the shared VPC"
+}
+
+variable "network_project" {
+  description = "ID of the project that will have shared VPC"
+}
+
+variable "org_id" {
+  description = "Organization ID"
+}
+
+variable "project_id" {
+  description = "ID of the project that will have forseti server"
+}
+
+variable "region" {
+  description = "Region where forseti subnetwork will be deployed"
+  default     = "us-central1"
+}
+
+variable "subnetwork" {
+  description = "Name of the subnetwork where forseti will be deployed"
+}

--- a/test/fixtures/simple_example/main.tf
+++ b/test/fixtures/simple_example/main.tf
@@ -54,6 +54,7 @@ module "forseti-install-simple" {
   region             = var.region
   network            = var.network
   subnetwork         = var.subnetwork
+  forseti_version    = var.forseti_version
 
   instance_metadata = {
     sshKeys = "ubuntu:${tls_private_key.main.public_key_openssh}"

--- a/test/fixtures/simple_example/variables.tf
+++ b/test/fixtures/simple_example/variables.tf
@@ -14,20 +14,17 @@
  * limitations under the License.
  */
 
+variable "domain" {
+ description = "The domain associated with the GCP Organization ID"
+}
+
 variable "gsuite_admin_email" {
   description = "The email of a GSuite super admin, used for pulling user directory information *and* sending notifications."
 }
 
-variable "project_id" {
-  description = "The ID of an existing Google project where Forseti will be installed"
-}
-
-variable "org_id" {
-  description = "GCP Organization ID that Forseti will have purview over"
-}
-
-variable "domain" {
-  description = "The domain associated with the GCP Organization ID"
+variable "forseti_version" {
+  description = "The version of Forseti to install"
+  default     = "master"
 }
 
 variable "instance_metadata" {
@@ -36,13 +33,21 @@ variable "instance_metadata" {
   default     = {}
 }
 
+variable "network" {
+  description = "Name of the shared VPC"
+}
+
+variable "org_id" {
+  description = "GCP Organization ID that Forseti will have purview over"
+}
+
+variable "project_id" {
+  description = "The ID of an existing Google project where Forseti will be installed"
+}
+
 variable "region" {
   description = "Region where forseti subnetwork will be deployed"
   default     = "us-central1"
-}
-
-variable "network" {
-  description = "Name of the shared VPC"
 }
 
 variable "subnetwork" {

--- a/test/fixtures/simple_example/variables.tf
+++ b/test/fixtures/simple_example/variables.tf
@@ -15,7 +15,7 @@
  */
 
 variable "domain" {
- description = "The domain associated with the GCP Organization ID"
+  description = "The domain associated with the GCP Organization ID"
 }
 
 variable "gsuite_admin_email" {


### PR DESCRIPTION
Added the forseti_version var to the shared_vpc and simple_example examples to default to the last release, and updated the corresponding test fixtures to use master branch of Forseti.

Resolves #377.