### PR TITLE
Add missing space.

### DIFF
--- a/modules/rules/templates/rules/location_rules.yaml
+++ b/modules/rules/templates/rules/location_rules.yaml
@@ -42,7 +42,7 @@
 #           - '*'
 #     locations:
 #       - 'us*'
-#  - name: All buckets in organization must not be in EU.
+#   - name: All buckets in organization must not be in EU.
 #     mode: blacklist
 #     resource:
 #       - type: organization


### PR DESCRIPTION
Missing a space in the yaml. If users just comment out the whole section and use the rule, then it will fail.