### PR TITLE
Add Service Account Key to CAI assets in config file

### DIFF
--- a/modules/server_config/templates/configs/forseti_conf_server.yaml.tpl
+++ b/modules/server_config/templates/configs/forseti_conf_server.yaml.tpl
@@ -186,6 +186,7 @@ inventory:
         #    - dns.googleapis.com/Policy
         #    - iam.googleapis.com/Role
         #    - iam.googleapis.com/ServiceAccount
+        #    - iam.googleapis.com/ServiceAccountKey
         #    - k8s.io/Namespace
         #    - k8s.io/Node
         #    - k8s.io/Pod


### PR DESCRIPTION
Related to PR [#3459](https://github.com/forseti-security/forseti-security/pull/3459).

Addresses Issue [#3232](https://github.com/forseti-security/forseti-security/issues/3232).