### PR TITLE
Conditonal service networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ For this module to work, you need the following APIs enabled on the Forseti proj
 | cscc\_violations\_enabled | Notify for CSCC violations | bool | `"false"` | no |
 | domain | The domain associated with the GCP Organization ID | string | n/a | yes |
 | enable\_cai\_bucket | Create a GCS bucket for CAI exports | bool | `"true"` | no |
+| enable\_service\_networking | Create a global service networking peering connection at the VPC level | bool | `"true"` | no |
 | enable\_write | Enabling/Disabling write actions | bool | `"false"` | no |
 | enabled\_apis\_enabled | Enabled APIs scanner enabled. | bool | `"false"` | no |
 | enabled\_apis\_violations\_should\_notify | Notify for enabled APIs violations | bool | `"true"` | no |

--- a/main.tf
+++ b/main.tf
@@ -176,6 +176,7 @@ module "cloudsql" {
   cloudsql_db_name           = var.cloudsql_db_name
   cloudsql_user_host         = var.cloudsql_user_host
   cloudsql_net_write_timeout = var.cloudsql_net_write_timeout
+  enable_service_networking  = var.enable_service_networking
   network_project            = var.network_project
   network                    = var.network
   project_id                 = var.project_id

--- a/modules/cloudsql/main.tf
+++ b/modules/cloudsql/main.tf
@@ -51,7 +51,7 @@ resource "google_compute_global_address" "private_ip_address" {
 }
 
 resource "google_service_networking_connection" "private_vpc_connection" {
-  count                   = var.cloudsql_private ? 1 : 0
+  count                   = var.enable_service_networking && var.cloudsql_private ? 1 : 0
   network                 = data.google_compute_network.cloudsql_private_network.self_link
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_address[count.index].name]

--- a/modules/cloudsql/variables.tf
+++ b/modules/cloudsql/variables.tf
@@ -41,6 +41,12 @@ variable "services" {
   default     = []
 }
 
+variable "enable_service_networking" {
+  description = "Create a global service networking peering connection at the VPC level"
+  type        = bool
+  default     = true
+}
+
 #------------#
 # Forseti db #
 #------------#

--- a/modules/on_gke/README.md
+++ b/modules/on_gke/README.md
@@ -66,6 +66,7 @@ This sub-module deploys Forseti on GKE.  In short, this deploys a server contain
 | cscc\_violations\_enabled | Notify for CSCC violations | bool | `"false"` | no |
 | domain | The domain associated with the GCP Organization ID | string | n/a | yes |
 | enable\_cai\_bucket | Create a GCS bucket for CAI exports | bool | `"true"` | no |
+| enable\_service\_networking | Create a global service networking peering connection at the VPC level | bool | `"true"` | no |
 | enable\_write | Enabling/Disabling write actions | bool | `"false"` | no |
 | enabled\_apis\_enabled | Enabled APIs scanner enabled. | bool | `"false"` | no |
 | enabled\_apis\_violations\_should\_notify | Notify for enabled APIs violations | bool | `"true"` | no |

--- a/modules/on_gke/main.tf
+++ b/modules/on_gke/main.tf
@@ -482,6 +482,7 @@ module "cloudsql" {
   cloudsql_db_name           = var.cloudsql_db_name
   cloudsql_user_host         = var.cloudsql_user_host
   cloudsql_net_write_timeout = var.cloudsql_net_write_timeout
+  enable_service_networking  = var.enable_service_networking
   network                    = var.network
   network_project            = var.network_project
   project_id                 = var.project_id

--- a/modules/on_gke/variables.tf
+++ b/modules/on_gke/variables.tf
@@ -752,6 +752,12 @@ variable "network_project" {
   default     = ""
 }
 
+variable "enable_service_networking" {
+  description = "Create a global service networking peering connection at the VPC level"
+  type        = bool
+  default     = true
+}
+
 #----------------#
 # Forseti client #
 #----------------#

--- a/variables.tf
+++ b/variables.tf
@@ -891,6 +891,12 @@ variable "network_project" {
   default     = ""
 }
 
+variable "enable_service_networking" {
+  description = "Create a global service networking peering connection at the VPC level"
+  type        = bool
+  default     = true
+}
+
 #-------#
 # Flags #
 #-------#


### PR DESCRIPTION
This PR make the creation of the Service Networking Connection optional and conditional on a boolean. The use case is strictly the same of https://github.com/forseti-security/terraform-google-forseti/pull/400

When you want to use CloudSQL privately and using a Shared VPC, you haven't automatically permissions to create such things. Moreover sometime the service networking connection already exist and in the VPC and you don't want to create another.