### PR TITLE
Add Cloud SQL DB User and Password as outputs

### DIFF
--- a/modules/cloudsql/outputs.tf
+++ b/modules/cloudsql/outputs.tf
@@ -47,4 +47,5 @@ output "forseti-cloudsql-user" {
 output "forseti-cloudsql-password" {
   description = "CloudSQL password"
   value       = local.cloudsql_password
+  sensitive   = true
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -52,7 +52,7 @@ output "forseti-cloudsql-password" {
 
 output "forseti-cloudsql-user" {
   description = "CloudSQL user"
-  value = module.cloudsql.forseti-cloudsql-user
+  value       = module.cloudsql.forseti-cloudsql-user
 }
 
 output "forseti-server-git-public-key-openssh" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -44,6 +44,17 @@ output "forseti-cloudsql-connection-name" {
   value       = module.cloudsql.forseti-cloudsql-connection-name
 }
 
+output "forseti-cloudsql-password" {
+  description = "CloudSQL password"
+  value       = module.cloudsql.forseti-cloudsql-password
+  sensitive   = true
+}
+
+output "forseti-cloudsql-user" {
+  description = "CloudSQL user"
+  value = module.cloudsql.forseti-cloudsql-user
+}
+
 output "forseti-server-git-public-key-openssh" {
   description = "The public OpenSSH key generated to allow the Forseti Server to clone the policy library repository."
   value       = module.server.forseti-server-git-public-key-openssh


### PR DESCRIPTION
Add the CloudSQL user and password as outputs of the root module. Mark the password output as sensitive. The Forseti end-to-end tests need the password in order to connect to the database.


Resolves #376