### PR TITLE
Fix providing of private SSH key (#410)

### DIFF
--- a/modules/on_gke/main.tf
+++ b/modules/on_gke/main.tf
@@ -116,7 +116,7 @@ data "local_file" "git_sync_private_ssh_key_file" {
 #------------------------------#
 
 data "tls_public_key" "git_sync_public_ssh_key" {
-  count           = var.config_validator_enabled && var.policy_library_sync_enabled ? 1 : 0
+  count           = local.create_policy_library_key ? 1 : 0
   private_key_pem = local.git_sync_private_ssh_key
 }
 


### PR DESCRIPTION
When providing an SSH private key via the parameter
git_sync_private_ssh_key_file, no public key gets
generated and therefore, we shouldn't try to extract
the public key part of that supplied file.