### PR TITLE
Allow user to configure Scanner Rules path to GCS or local dir

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -320,6 +320,7 @@ module "server_config" {
   violations_slack_webhook                            = var.violations_slack_webhook
   cscc_violations_enabled                             = var.cscc_violations_enabled
   cscc_source_id                                      = var.cscc_source_id
+  rules_path                                          = var.rules_path
 
   groups_settings_max_calls                = var.groups_settings_max_calls
   groups_settings_period                   = var.groups_settings_period

--- a/variables.tf
+++ b/variables.tf
@@ -553,6 +553,12 @@ variable "service_account_key_enabled" {
   default     = true
 }
 
+variable "rules_path" {
+  description = "Path for Scanner Rules config files; if GCS, should be gs://bucket-name/path"
+  type        = string
+  default     = "/home/ubuntu/forseti-security/rules"
+}
+
 #--------------------------------#
 # Forseti server config notifier #
 #--------------------------------#


### PR DESCRIPTION
This PR will allow a Terraform Forseti user to provide a rules_path as input to the top-level forseti module, and have that propagate down into the server_config module. We have tested to ensure this works with a GCS path only (not a local dir, although that is the default behavior so this should not affect that). @blueandgold 