### PR TITLE
Remove the % character from the Cloud SQL password

### DIFF
--- a/modules/cloudsql/main.tf
+++ b/modules/cloudsql/main.tf
@@ -119,7 +119,7 @@ resource "google_sql_user" "forseti_user" {
 resource "random_password" "password" {
   length           = 16
   special          = true
-  override_special = "_%@"
+  override_special = "_@"
 }
 
 resource "null_resource" "services-dependency" {


### PR DESCRIPTION
Remove the % character from the list of possible special characters to use in the random Cloud SQL password.

Resolves #416 