### PR TITLE
Base64 encode cloudsql username and password for the helm chart secrets.

### DIFF
--- a/modules/on_gke/main.tf
+++ b/modules/on_gke/main.tf
@@ -241,12 +241,12 @@ resource "helm_release" "forseti-security" {
 
   set {
     name  = "database.username"
-    value = module.cloudsql.forseti-cloudsql-user
+    value = "${base64encode(module.cloudsql.forseti-cloudsql-user)}"
   }
 
   set_sensitive {
     name  = "database.password"
-    value = module.cloudsql.forseti-cloudsql-password
+    value = "${base64encode(module.cloudsql.forseti-cloudsql-password)}"
   }
 
   set {

--- a/test/fixtures/shared_vpc/variables.tf
+++ b/test/fixtures/shared_vpc/variables.tf
@@ -20,7 +20,7 @@ variable "domain" {
 
 variable "forseti_version" {
   description = "The version of Forseti to install"
-  default     = "master"
+  default     = "v2.25.0"
 }
 
 variable "gsuite_admin_email" {

--- a/test/fixtures/simple_example/variables.tf
+++ b/test/fixtures/simple_example/variables.tf
@@ -24,7 +24,7 @@ variable "gsuite_admin_email" {
 
 variable "forseti_version" {
   description = "The version of Forseti to install"
-  default     = "master"
+  default     = "v2.25.0"
 }
 
 variable "instance_metadata" {


### PR DESCRIPTION
Tested this change fixes the helm charts.

Resolves #418