### PR TITLE
Style fixes

### DIFF
--- a/examples/on_gke/main.tf
+++ b/examples/on_gke/main.tf
@@ -70,7 +70,7 @@ provider "kubernetes" {
   load_config_file       = false
   host                   = "https://${data.google_container_cluster.forseti_cluster.endpoint}"
   token                  = data.google_client_config.default.access_token
-  cluster_ca_certificate = "${base64decode(data.google_container_cluster.forseti_cluster.master_auth.0.cluster_ca_certificate)}"
+  cluster_ca_certificate = base64decode(data.google_container_cluster.forseti_cluster.master_auth.0.cluster_ca_certificate)
 }
 
 #---------------#
@@ -85,7 +85,7 @@ provider "helm" {
     load_config_file       = false
     host                   = "https://${data.google_container_cluster.forseti_cluster.endpoint}"
     token                  = data.google_client_config.default.access_token
-    cluster_ca_certificate = "${base64decode(data.google_container_cluster.forseti_cluster.master_auth.0.cluster_ca_certificate)}"
+    cluster_ca_certificate = base64decode(data.google_container_cluster.forseti_cluster.master_auth.0.cluster_ca_certificate)
   }
   debug                           = true
   automount_service_account_token = true

--- a/examples/on_gke_end_to_end/main.tf
+++ b/examples/on_gke_end_to_end/main.tf
@@ -39,7 +39,7 @@ provider "kubernetes" {
   load_config_file       = false
   host                   = "https://${module.gke.endpoint}"
   token                  = data.google_client_config.default.access_token
-  cluster_ca_certificate = "${base64decode(module.gke.ca_certificate)}"
+  cluster_ca_certificate = base64decode(module.gke.ca_certificate)
 }
 
 //*****************************************
@@ -53,8 +53,8 @@ provider "helm" {
   kubernetes {
     load_config_file       = false
     host                   = "https://${module.gke.endpoint}"
-    token                  = "${data.google_client_config.default.access_token}"
-    cluster_ca_certificate = "${base64decode(module.gke.ca_certificate)}"
+    token                  = data.google_client_config.default.access_token
+    cluster_ca_certificate = base64decode(module.gke.ca_certificate)
   }
   debug                           = true
   automount_service_account_token = true
@@ -81,7 +81,7 @@ module "vpc" {
   }, ]
 
   secondary_ranges = {
-    "${var.subnetwork}" = [
+    var.subnetwork = [
       {
         range_name    = var.gke_pod_ip_range_name
         ip_cidr_range = var.gke_pod_ip_range

--- a/modules/on_gke/main.tf
+++ b/modules/on_gke/main.tf
@@ -241,12 +241,12 @@ resource "helm_release" "forseti-security" {
 
   set {
     name  = "database.username"
-    value = "${base64encode(module.cloudsql.forseti-cloudsql-user)}"
+    value = base64encode(module.cloudsql.forseti-cloudsql-user)
   }
 
   set_sensitive {
     name  = "database.password"
-    value = "${base64encode(module.cloudsql.forseti-cloudsql-password)}"
+    value = base64encode(module.cloudsql.forseti-cloudsql-password)
   }
 
   set {
@@ -276,7 +276,7 @@ resource "helm_release" "forseti-security" {
 
   set_string {
     name  = "server.config.contents"
-    value = "${base64encode(data.http.server_config_contents.body)}"
+    value = base64encode(data.http.server_config_contents.body)
   }
 
   set {
@@ -346,7 +346,7 @@ resource "helm_release" "forseti-security" {
 
   set_sensitive {
     name  = "configValidator.policyLibrary.gitSync.privateSSHKey"
-    value = "${base64encode(local.git_sync_private_ssh_key)}"
+    value = base64encode(local.git_sync_private_ssh_key)
   }
 
   set {

--- a/modules/real_time_enforcer/main.tf
+++ b/modules/real_time_enforcer/main.tf
@@ -47,18 +47,18 @@ locals {
 
   network_interface_base = {
     private = [{
-      subnetwork_project = "${local.network_project}"
-      subnetwork         = "${var.subnetwork}"
+      subnetwork_project = local.network_project
+      subnetwork         = var.subnetwork
     }]
 
     public = [{
-      subnetwork_project = "${local.network_project}"
-      subnetwork         = "${var.subnetwork}"
-      access_config      = ["${var.enforcer_instance_access_config}"]
+      subnetwork_project = local.network_project
+      subnetwork         = var.subnetwork
+      access_config      = [var.enforcer_instance_access_config]
     }]
   }
 
-  network_interface = "${local.network_interface_base[var.enforcer_instance_private ? "private" : "public"]}"
+  network_interface = local.network_interface_base[var.enforcer_instance_private ? "private" : "public"]
 }
 
 resource "google_service_account" "main" {

--- a/modules/rules/templates/rules/groups_settings_rules.yaml
+++ b/modules/rules/templates/rules/groups_settings_rules.yaml
@@ -40,7 +40,6 @@ rules:
     groups_emails:
       - '*'
     settings:
-      allowExternalMembers: True
       whoCanJoin: "INVITED_CAN_JOIN"
       whoCanInvite: "ALL_MANAGERS_CAN_INVITE"
       whoCanAdd: "ALL_MANAGERS_CAN_ADD"

--- a/test/fixtures/real_time_enforcer/main.tf
+++ b/test/fixtures/real_time_enforcer/main.tf
@@ -38,7 +38,7 @@ module "bastion" {
   source = "../bastion"
 
   network    = var.network
-  project_id = "${var.project_id}"
+  project_id = var.project_id
   subnetwork = var.subnetwork
   zone       = data.google_compute_zones.main.names[0]
 }

--- a/test/fixtures/real_time_enforcer/outputs.tf
+++ b/test/fixtures/real_time_enforcer/outputs.tf
@@ -15,7 +15,7 @@
  */
 
 output "bastion_host" {
-  value       = "${module.bastion.host}"
+  value       = module.bastion.host
   description = "Bastion host"
 }
 


### PR DESCRIPTION
- convert all quoted references to HCL2 format (as quoted references generate deprecation warnings in newest versions of Terraform)
- remove duplicated key from `modules/rules/templates/rules/groups_settings_rules.yaml`, as you can't have duplicates in yaml and I think only the last one is taken into account.