### PR TITLE
Set Google Provider version to 2.11.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -18,7 +18,7 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    google   = "~> 2.11"
+    google   = "2.11.0"
     null     = "~> 2.0"
     template = "~> 2.0"
     random   = "~> 2.0"


### PR DESCRIPTION
Set the version for the Google provider to 2.11.0. The current syntax is using Google Provider version >= 2.11.0 and < 3.0. This is causing the Provider version to be 2.20.1 which was released on December 13 2019.

Resolves #433