### PR TITLE
Fix the Bigquery API issue for release 5.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ gcloud auth login
 The repository has several helper scripts that can be used with the deployment process.
 
 ```bash
-git clone --branch module-release-5.0.0 --depth 1 https://github.com/forseti-security/terraform-google-forseti.git
+git clone --branch modulerelease520 --depth 1 https://github.com/forseti-security/terraform-google-forseti.git
 ```
 
 ### Install Terraform
@@ -62,7 +62,7 @@ Create a file named `main.tf` in an empty directory and copy the contents below 
 ```hcl
     module "forseti" {
       source  = "terraform-google-modules/forseti/google"
-      version = "~> 5.0.0"
+      version = "~> 5.2.0"
 
       gsuite_admin_email = "superadmin@yourdomain.com"
       domain             = "yourdomain.com"

--- a/README.md
+++ b/README.md
@@ -337,6 +337,8 @@ For this module to work, you need the following APIs enabled on the Forseti proj
 | forseti-client-vm-ip | Forseti Client VM private IP address |
 | forseti-client-vm-name | Forseti Client VM name |
 | forseti-cloudsql-connection-name | Forseti CloudSQL Connection String |
+| forseti-cloudsql-password | CloudSQL password |
+| forseti-cloudsql-user | CloudSQL user |
 | forseti-server-git-public-key-openssh | The public OpenSSH key generated to allow the Forseti Server to clone the policy library repository. |
 | forseti-server-service-account | Forseti Server service account |
 | forseti-server-storage-bucket | Forseti Server storage bucket |

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -38,4 +38,4 @@ tags:
 - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.1.0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.4.6'

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -21,4 +21,4 @@ tags:
 - 'lint'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.1.0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.4.6'

--- a/examples/install_simple/main.tf
+++ b/examples/install_simple/main.tf
@@ -37,7 +37,7 @@ provider "random" {
 
 module "forseti-install-simple" {
   source  = "terraform-google-modules/forseti/google"
-  version = "~> 5.2.0"
+  version = "~> 5.1.0"
 
   project_id = var.project_id
   org_id     = var.org_id

--- a/examples/install_simple/main.tf
+++ b/examples/install_simple/main.tf
@@ -37,7 +37,7 @@ provider "random" {
 
 module "forseti-install-simple" {
   source  = "terraform-google-modules/forseti/google"
-  version = "~> 5.0.0"
+  version = "~> 5.2.0"
 
   project_id = var.project_id
   org_id     = var.org_id

--- a/examples/migrate_forseti/main.tf
+++ b/examples/migrate_forseti/main.tf
@@ -40,7 +40,7 @@ provider "random" {
 
 module "forseti" {
   source  = "terraform-google-modules/forseti/google"
-  version = "~> 5.0.0"
+  version = "~> 5.2.0"
 
   # Replace these argument values with those obtained in the Prerequisites section
   domain               = "DOMAIN"

--- a/examples/migrate_forseti/main.tf
+++ b/examples/migrate_forseti/main.tf
@@ -40,7 +40,7 @@ provider "random" {
 
 module "forseti" {
   source  = "terraform-google-modules/forseti/google"
-  version = "~> 5.2.0"
+  version = "~> 5.1.0"
 
   # Replace these argument values with those obtained in the Prerequisites section
   domain               = "DOMAIN"

--- a/examples/migrate_forseti/tutorial.md
+++ b/examples/migrate_forseti/tutorial.md
@@ -30,7 +30,7 @@ Before you begin the migration process, you will need:
 - The suffix appended to the names of the Forseti resources; this is
   likely a string of seven characters like a1b2c3d.
 - A service account for the organization with the
-  [roles required by the Terraform module](https://registry.terraform.io/modules/terraform-google-modules/forseti/google/5.0.0#iam-roles).
+  [roles required by the Terraform module](https://registry.terraform.io/modules/terraform-google-modules/forseti/google/5.2.0#iam-roles).
 - A
   [JSON key file](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating_service_account_keys)
   for the service account.
@@ -160,7 +160,7 @@ to match the region where the CAI GCS bucket is deployed.
 Starting with Forseti Security 2.23, Terraform will manage your server
  configuration file for you.  Configuration options will now be input
  variables that are defined in the Terraform module. Available variables
- and their default values can be found [here](https://github.com/forseti-security/terraform-google-forseti/blob/module-release-5.0.0/variables.tf).
+ and their default values can be found [here](https://github.com/forseti-security/terraform-google-forseti/blob/module-release-5.2.0/variables.tf).
  Default values will be used if values are not explicitly added.
  This will ensure upgrading Forseti will be as easy as possible going forward.
 
@@ -202,10 +202,10 @@ to your <walkthrough-editor-select-regex
   regex="Add any Forseti Server Configuration Variables Here">main.tf</walkthrough-editor-select-regex>.
 
 ## Obtain and Run the Import Script
-This [import script](https://github.com/forseti-security/terraform-google-forseti/blob/module-release-5.0.0/helpers/import.sh) will import the Forseti GCP resources into a local state file.
+This [import script](https://github.com/forseti-security/terraform-google-forseti/blob/module-release-5.2.0/helpers/import.sh) will import the Forseti GCP resources into a local state file.
 
 ```sh
-curl --location --remote-name https://raw.githubusercontent.com/forseti-security/terraform-google-forseti/module-release-5.0.0/helpers/import.sh
+curl --location --remote-name https://raw.githubusercontent.com/forseti-security/terraform-google-forseti/module-release-5.2.0/helpers/import.sh
 chmod +x import.sh
 ./import.sh -h
 ```

--- a/examples/migrate_forseti/tutorial.md
+++ b/examples/migrate_forseti/tutorial.md
@@ -160,7 +160,7 @@ to match the region where the CAI GCS bucket is deployed.
 Starting with Forseti Security 2.23, Terraform will manage your server
  configuration file for you.  Configuration options will now be input
  variables that are defined in the Terraform module. Available variables
- and their default values can be found [here](https://github.com/forseti-security/terraform-google-forseti/blob/module-release-5.2.0/variables.tf).
+ and their default values can be found [here](https://github.com/forseti-security/terraform-google-forseti/blob/modulerelease520/variables.tf).
  Default values will be used if values are not explicitly added.
  This will ensure upgrading Forseti will be as easy as possible going forward.
 
@@ -202,10 +202,10 @@ to your <walkthrough-editor-select-regex
   regex="Add any Forseti Server Configuration Variables Here">main.tf</walkthrough-editor-select-regex>.
 
 ## Obtain and Run the Import Script
-This [import script](https://github.com/forseti-security/terraform-google-forseti/blob/module-release-5.2.0/helpers/import.sh) will import the Forseti GCP resources into a local state file.
+This [import script](https://github.com/forseti-security/terraform-google-forseti/blob/modulerelease520/helpers/import.sh) will import the Forseti GCP resources into a local state file.
 
 ```sh
-curl --location --remote-name https://raw.githubusercontent.com/forseti-security/terraform-google-forseti/module-release-5.2.0/helpers/import.sh
+curl --location --remote-name https://raw.githubusercontent.com/forseti-security/terraform-google-forseti/modulerelease520/helpers/import.sh
 chmod +x import.sh
 ./import.sh -h
 ```

--- a/helpers/import.sh
+++ b/helpers/import.sh
@@ -150,7 +150,7 @@ printf "\nStarting import of Forseti resources to Terraform\n\n"
 
 terraform import "module.$MODULE_LOCAL_NAME.google_project_service.main[0]" "$PROJECT_ID/admin.googleapis.com"
 terraform import "module.$MODULE_LOCAL_NAME.google_project_service.main[1]" "$PROJECT_ID/appengine.googleapis.com"
-terraform import "module.$MODULE_LOCAL_NAME.google_project_service.main[2]" "$PROJECT_ID/bigquery-json.googleapis.com"
+terraform import "module.$MODULE_LOCAL_NAME.google_project_service.main[2]" "$PROJECT_ID/bigquery.googleapis.com"
 terraform import "module.$MODULE_LOCAL_NAME.google_project_service.main[3]" "$PROJECT_ID/cloudbilling.googleapis.com"
 terraform import "module.$MODULE_LOCAL_NAME.google_project_service.main[4]" "$PROJECT_ID/cloudresourcemanager.googleapis.com"
 terraform import "module.$MODULE_LOCAL_NAME.google_project_service.main[5]" "$PROJECT_ID/sql-component.googleapis.com"

--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ locals {
   services_list = [
     "admin.googleapis.com",
     "appengine.googleapis.com",
-    "bigquery-json.googleapis.com",
+    "bigquery.googleapis.com",
     "cloudbilling.googleapis.com",
     "cloudresourcemanager.googleapis.com",
     "sql-component.googleapis.com",

--- a/modules/on_gke/README.md
+++ b/modules/on_gke/README.md
@@ -97,7 +97,7 @@ This sub-module deploys Forseti on GKE.  In short, this deploys a server contain
 | groups\_settings\_violations\_should\_notify | Notify for groups settings violations | bool | `"true"` | no |
 | groups\_violations\_should\_notify | Notify for Groups violations | bool | `"true"` | no |
 | gsuite\_admin\_email | G-Suite administrator email address to manage your Forseti installation | string | `""` | no |
-| helm\_chart\_version | The version of the Helm chart to use | string | `"2.1.0"` | no |
+| helm\_chart\_version | The version of the Helm chart to use | string | `"2.2.0"` | no |
 | helm\_repository\_url | The Helm repository containing the 'forseti-security' Helm charts | string | `"https://forseti-security-charts.storage.googleapis.com/release/"` | no |
 | iam\_disable\_polling | Whether to disable polling for IAM API | bool | `"false"` | no |
 | iam\_max\_calls | Maximum calls that can be made to IAM API | string | `"90"` | no |

--- a/modules/on_gke/main.tf
+++ b/modules/on_gke/main.tf
@@ -54,7 +54,7 @@ locals {
   services_list = [
     "admin.googleapis.com",
     "appengine.googleapis.com",
-    "bigquery-json.googleapis.com",
+    "bigquery.googleapis.com",
     "cloudbilling.googleapis.com",
     "cloudresourcemanager.googleapis.com",
     "sql-component.googleapis.com",

--- a/modules/rules/templates/rules/enabled_apis_rules.yaml
+++ b/modules/rules/templates/rules/enabled_apis_rules.yaml
@@ -21,7 +21,7 @@
 #         resource_ids:
 #           - '*'
 #     services:
-#       - 'bigquery-json.googleapis.com'
+#       - 'bigquery.googleapis.com'
 #       - 'clouddebugger.googleapis.com'
 #       - 'cloudtrace.googleapis.com'
 #       - 'compute.googleapis.com'


### PR DESCRIPTION
Update release 5.2.0 for the bigquery change. Update a few remaining places where 5.0.0 was still being used instead of 5.2.0.