### PR TITLE
Fix validate error

### DIFF
--- a/examples/on_gke_end_to_end/main.tf
+++ b/examples/on_gke_end_to_end/main.tf
@@ -81,7 +81,7 @@ module "vpc" {
   }, ]
 
   secondary_ranges = {
-    var.subnetwork = [
+    "${var.subnetwork}" = [
       {
         range_name    = var.gke_pod_ip_range_name
         ip_cidr_range = var.gke_pod_ip_range


### PR DESCRIPTION
Wrapping this map key in parentheses does not fix the issue - https://github.com/hashicorp/terraform/issues/21566. Instead using string interpolation resolves the validation error but might show up as a lint error related to moving to HCL2 expressions.