### PR TITLE
Increased open files limit to fix OSError: [Errno 24] Too many open files 

### DIFF
--- a/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
+++ b/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
@@ -155,8 +155,17 @@ systemctl enable --now forseti
 echo "Forseti Startup - Success! The Forseti API server has been enabled and started."
 
 # Increase Open File Limit
-echo "ubuntu soft nofile 32768" | sudo tee -a /etc/security/limits.conf
-echo "ubuntu hard nofile 32768" | sudo tee -a /etc/security/limits.conf
+if grep -q "ubuntu soft nofile" /etc/security/limits.conf ; then
+  echo "Ulimit soft nofile already set."
+else
+  echo "ubuntu soft nofile 32768" | sudo tee -a /etc/security/limits.conf
+fi
+
+if grep -q "ubuntu hard nofile" /etc/security/limits.conf ; then
+  echo "Ulimit hard nofile already set."
+else
+  echo "ubuntu hard nofile 32768" | sudo tee -a /etc/security/limits.conf
+fi
 
 # Create a Forseti env script
 FORSETI_ENV="$(cat << EOF

--- a/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
+++ b/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
@@ -154,6 +154,10 @@ echo "Forseti Startup - Enabling and starting Forseti service."
 systemctl enable --now forseti
 echo "Forseti Startup - Success! The Forseti API server has been enabled and started."
 
+# Increase Open File Limit
+echo "ubuntu soft nofile 32768" | sudo tee -a /etc/security/limits.conf
+echo "ubuntu hard nofile 32768" | sudo tee -a /etc/security/limits.conf
+
 # Create a Forseti env script
 FORSETI_ENV="$(cat << EOF
 #!/bin/bash


### PR DESCRIPTION
This PR fixes OSError: [Errno 24] Too many open files error reported in [this issue](https://github.com/forseti-security/forseti-security/issues/3425).

