### PR TITLE
Add spanner.googleapis.com to 5.2.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -60,6 +60,7 @@ locals {
     "cloudasset.googleapis.com",
     "storage-api.googleapis.com",
     "groupssettings.googleapis.com",
+    "spanner.googleapis.com",
   ]
 
   cscc_violations_enabled_services_list = [


### PR DESCRIPTION
Add spanner.googleapis.com service to main.tf in order to collect Cloud Spanner resources.

Addresses forseti-security/forseti-security#3572