### PR TITLE
Upgraded to the latest version of the Google provider

### DIFF
--- a/examples/external_ip/main.tf
+++ b/examples/external_ip/main.tf
@@ -16,7 +16,7 @@
 
 provider "google" {
   credentials = file(var.credentials_path)
-  version     = "~> 2.11.0"
+  version     = "3.4.0"
 }
 
 provider "null" {

--- a/examples/install_simple/main.tf
+++ b/examples/install_simple/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 2.11.0"
+  version = "3.4.0"
   project = var.project_id
 }
 

--- a/examples/migrate_forseti/main.tf
+++ b/examples/migrate_forseti/main.tf
@@ -19,7 +19,7 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 2.11.0"
+  version = "3.4.0"
 }
 
 provider "local" {

--- a/examples/on_gke/main.tf
+++ b/examples/on_gke/main.tf
@@ -27,7 +27,7 @@ locals {
 #------------------#
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "3.4.0"
   project = var.project_id
 }
 

--- a/examples/on_gke_end_to_end/main.tf
+++ b/examples/on_gke_end_to_end/main.tf
@@ -19,7 +19,7 @@
 #------------------#
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "3.4.0"
   project = var.project_id
 }
 

--- a/examples/real_time_enforcer/main.tf
+++ b/examples/real_time_enforcer/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 2.11.0"
+  version = "3.4.0"
 }
 
 provider "null" {

--- a/examples/shared_vpc/main.tf
+++ b/examples/shared_vpc/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 2.11.0"
+  version = "3.4.0"
 }
 
 provider "google-beta" {

--- a/examples/simple_example/main.tf
+++ b/examples/simple_example/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 2.11.0"
+  version = "3.4.0"
   project = var.project_id
 }
 

--- a/test/fixtures/real_time_enforcer/modules/enforcer_target/main.tf
+++ b/test/fixtures/real_time_enforcer/modules/enforcer_target/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 2.11.0"
+  version = "3.4.0"
 }
 
 resource "random_string" "main" {

--- a/test/fixtures/real_time_enforcer_roles/main.tf
+++ b/test/fixtures/real_time_enforcer_roles/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 2.11.0"
+  version = "3.4.0"
 }
 
 resource "random_string" "main" {

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -19,7 +19,7 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "3.4.0"
 }
 
 provider "google-beta" {


### PR DESCRIPTION
Resolves #388 

To avoid errors during linting and Forseti deployments, upgraded to the latest version of the Google provider and pinned that particular version.