### PR TITLE
Sync policy library with gsutil rsync

### DIFF
--- a/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
+++ b/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
@@ -113,14 +113,10 @@ if [ "${policy_library_sync_enabled}" == "true" ]; then
   sudo mkdir -p /etc/git-secret
   sudo gsutil cp -n gs://${storage_bucket_name}/${policy_library_sync_gcs_directory_name}/* /etc/git-secret/
 else
-  # DEPRECATED! Remove once users have migrated over to Git-Sync
   # Download the Newest Config Validator constraints from GCS
   echo "Forseti Startup - Copying Policy Library from GCS."
-
-  # Attempt to download the config-validator policy and gracefully handle the absence
-  # of policy files.  The config-validator is not required for the rest of Forseti
-  # and should not halt installation.
-  gsutil cp -r gs://${storage_bucket_name}/policy-library ${policy_library_home}/ || echo "No policy available, continuing with Forseti installation"
+  sudo mkdir -m 777 -p ${policy_library_home}/policy-library
+  gsutil -m rsync -d -r gs://${storage_bucket_name}/policy-library ${policy_library_home}/policy-library || echo "No policy available, continuing with Forseti installation"
 fi
 
 # Enable cloud-profiler in the initialize_forseti_services.sh script

--- a/test/fixtures/install_simple/policy-library/lib/constraints.rego
+++ b/test/fixtures/install_simple/policy-library/lib/constraints.rego
@@ -1,0 +1,36 @@
+#
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package validator.gcp.lib
+
+# Function to fetch the constraint spec
+# Usage:
+# get_constraint_params(constraint, params)
+
+get_constraint_params(constraint) = params {
+	params := constraint.spec.parameters
+}
+
+# Function to fetch constraint info
+# Usage:
+# get_constraint_info(constraint, info)
+
+get_constraint_info(constraint) = info {
+	info := {
+		"name": constraint.metadata.name,
+		"kind": constraint.kind,
+	}
+}

--- a/test/fixtures/install_simple/policy-library/lib/util.rego
+++ b/test/fixtures/install_simple/policy-library/lib/util.rego
@@ -1,0 +1,46 @@
+#
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package validator.gcp.lib
+
+# has_field returns whether an object has a field
+has_field(object, field) {
+	object[field]
+}
+
+# False is a tricky special case, as false responses would create an undefined document unless
+# they are explicitly tested for
+has_field(object, field) {
+	object[field] == false
+}
+
+has_field(object, field) = false {
+	not object[field]
+	not object[field] == false
+}
+
+# get_default returns the value of an object's field or the provided default value.
+# It avoids creating an undefined state when trying to access an object attribute that does
+# not exist
+get_default(object, field, _default) = output {
+	has_field(object, field)
+	output = object[field]
+}
+
+get_default(object, field, _default) = output {
+	has_field(object, field) == false
+	output = _default
+}

--- a/test/fixtures/install_simple/policy-library/lib/util_test.rego
+++ b/test/fixtures/install_simple/policy-library/lib/util_test.rego
@@ -1,0 +1,51 @@
+#
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package validator.gcp.lib
+
+# has_field tests
+test_has_field_exists {
+	obj := {"a": "b"}
+	true == has_field(obj, "a")
+}
+
+# False is a tricky special case, as false responses would create an undefined document unless
+# they are explicitly tested for
+test_has_field_false {
+	obj := {"a": false}
+	true == has_field(obj, "a")
+}
+
+test_has_field_no_field {
+	obj := {}
+	false == has_field(obj, "a")
+}
+
+# get_default_tests
+test_get_default_exists {
+	obj := {"a": "b"}
+	"b" == get_default(obj, "a", "q")
+}
+
+test_get_default_not_exists {
+	obj := {}
+	"q" == get_default(obj, "a", "q")
+}
+
+test_get_default_has_false {
+	obj := {"a": false}
+	false == get_default(obj, "a", "b")
+}

--- a/test/fixtures/install_simple/policy-library/policies/constraints/sql_public_ip.yaml
+++ b/test/fixtures/install_simple/policy-library/policies/constraints/sql_public_ip.yaml
@@ -1,0 +1,28 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPSQLPublicIpConstraintV1
+metadata:
+  name: prevent-public-ip-cloudsql
+  annotations:
+    description: Prevents a public IP from being assigned to a Cloud SQL instance.
+    bundles.validator.forsetisecurity.org/scorecard-v1: security
+    # This constraint has not been validated by the formal CIS certification process.
+    bundles.validator.forsetisecurity.org/cis-v1.1: 6.05
+spec:
+  severity: high
+  match:
+    target: ["organization/*"]
+    exclude: [] # optional, default is no exclusions

--- a/test/fixtures/install_simple/policy-library/policies/templates/gcp_sql_public_ip_v1.yaml
+++ b/test/fixtures/install_simple/policy-library/policies/templates/gcp_sql_public_ip_v1.yaml
@@ -1,0 +1,64 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: templates.gatekeeper.sh/v1alpha1
+kind: ConstraintTemplate
+metadata:
+  name: gcp-sql-public-ip-v1
+spec:
+  crd:
+    spec:
+      names:
+        kind: GCPSQLPublicIpConstraintV1
+      validation:
+        openAPIV3Schema:
+          properties: {}
+  targets:
+    validation.gcp.forsetisecurity.org:
+      rego: | #INLINE("validator/sql_public_ip.rego")
+         #
+         # Copyright 2018 Google LLC
+         #
+         # Licensed under the Apache License, Version 2.0 (the "License");
+         # you may not use this file except in compliance with the License.
+         # You may obtain a copy of the License at
+         #
+         #      http://www.apache.org/licenses/LICENSE-2.0
+         #
+         # Unless required by applicable law or agreed to in writing, software
+         # distributed under the License is distributed on an "AS IS" BASIS,
+         # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+         # See the License for the specific language governing permissions and
+         # limitations under the License.
+         #
+         
+         package templates.gcp.GCPSQLPublicIpConstraintV1
+         
+         import data.validator.gcp.lib as lib
+         
+         deny[{
+         	"msg": message,
+         	"details": metadata,
+         }] {
+         	asset := input.asset
+         	asset.asset_type == "sqladmin.googleapis.com/Instance"
+         
+         	ip_config := lib.get_default(asset.resource.data.settings, "ipConfiguration", {})
+         	ipv4 := lib.get_default(ip_config, "ipv4Enabled", true)
+         	ipv4 == true
+         
+         	message := sprintf("%v is not allowed to have a Public IP.", [asset.name])
+         	metadata := {"resource": asset.name}
+         }
+         #ENDINLINE

--- a/test/integration/install_simple/controls/server.rb
+++ b/test/integration/install_simple/controls/server.rb
@@ -504,7 +504,7 @@ control "server" do
   ]
 
   expected_policy_files.each do |file|
-    describe file("$POLICY_LIBRARY_HOME/#{file}") do
+    describe file("/home/ubuntu/policy-library/#{file}") do
       it { should exist }
       it "is valid YAML" do
         YAML.load(subject.content)

--- a/test/integration/install_simple/controls/server.rb
+++ b/test/integration/install_simple/controls/server.rb
@@ -493,4 +493,22 @@ control "server" do
     its("exit_status") { should eq 0 }
     its("stdout") { should match("- name: net_write_timeout\n    value: '240'") }
   end
+
+  # Assert Policy Library is copied from GCS correctly
+  expected_policy_files = [
+    "policy-library/lib/constraints.rego",
+    "policy-library/lib/util_test.rego",
+    "policy-library/lib/util.rego",
+    "policy-library/policies/constraints/sql_public_ip.yaml",
+    "policy-library/policies/templates/gcp_sql_public_ip_v1.yaml"
+  ]
+
+  expected_policy_files.each do |file|
+    describe file("$POLICY_LIBRARY_HOME/#{file}") do
+      it { should exist }
+      it "is valid YAML" do
+        YAML.load(subject.content)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Switch the gcs sync for the policy library to use gsutil rsync instead of gsutil cp. If a user deletes a policy from GCS, that policy would not get deleted from the local policy library on the Forseti server, so Forseti would continue to scan with it. The gsutil rsync command will ensure that the GCS directory and local policy library are in sync.

I tested by making several changes on the GCS policy, reset the server and ensured that the files deleted were deleted from the local policy library. This PR will ensure the two directories are in sync only during a VM reset. There is another [PR](https://github.com/forseti-security/terraform-google-forseti/pull/457) to move the run_forseti.sh script to the Terraform repo, and will ensure that takes care of syncing the policies as well.

Sample VM logs showing files getting deleted:
```
Jan 24 23:47:57 forseti-server-vm-fe73bca2 startup-script: INFO startup-script: Forseti Startup - Copying Policy Library from GCS.
Jan 24 23:47:57 forseti-server-vm-fe73bca2 startup-script: INFO startup-script: Building synchronization state...
Jan 24 23:47:58 forseti-server-vm-fe73bca2 startup-script: INFO startup-script: Starting synchronization...
Jan 24 23:47:58 forseti-server-vm-fe73bca2 startup-script: INFO startup-script: Removing file:///home/ubuntu/policy-library/policy-library/policies/templates/gcp_always_violates_v1.yaml
Jan 24 23:47:58 forseti-server-vm-fe73bca2 startup-script: INFO startup-script: Removing file:///home/ubuntu/policy-library/policy-library/policies/templates/gcp_allowed_resource_types_v1.yaml
Jan 24 23:47:58 forseti-server-vm-fe73bca2 startup-script: INFO startup-script: Removing file:///home/ubuntu/policy-library/policy-library/policies/templates/gcp_app_service_versions.yaml
```

Resolves #461 