### PR TITLE
Fix Cloud Shell tutorial for Release 5.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ gcloud auth login
 The repository has several helper scripts that can be used with the deployment process.
 
 ```bash
-git clone --branch module-release-5.0.0 --depth 1 https://github.com/forseti-security/terraform-google-forseti.git
+git clone --branch modulerelease510 --depth 1 https://github.com/forseti-security/terraform-google-forseti.git
 ```
 
 ### Install Terraform
@@ -62,7 +62,7 @@ Create a file named `main.tf` in an empty directory and copy the contents below 
 ```hcl
     module "forseti" {
       source  = "terraform-google-modules/forseti/google"
-      version = "~> 5.0.0"
+      version = "~> 5.1"
 
       gsuite_admin_email = "superadmin@yourdomain.com"
       domain             = "yourdomain.com"

--- a/examples/install_simple/main.tf
+++ b/examples/install_simple/main.tf
@@ -37,7 +37,7 @@ provider "random" {
 
 module "forseti-install-simple" {
   source  = "terraform-google-modules/forseti/google"
-  version = "~> 5.0.0"
+  version = "~> 5.1"
 
   project_id = var.project_id
   org_id     = var.org_id

--- a/examples/migrate_forseti/main.tf
+++ b/examples/migrate_forseti/main.tf
@@ -40,7 +40,7 @@ provider "random" {
 
 module "forseti" {
   source  = "terraform-google-modules/forseti/google"
-  version = "~> 5.0.0"
+  version = "~> 5.1"
 
   # Replace these argument values with those obtained in the Prerequisites section
   domain               = "DOMAIN"

--- a/helpers/import.sh
+++ b/helpers/import.sh
@@ -150,7 +150,7 @@ printf "\nStarting import of Forseti resources to Terraform\n\n"
 
 terraform import "module.$MODULE_LOCAL_NAME.google_project_service.main[0]" "$PROJECT_ID/admin.googleapis.com"
 terraform import "module.$MODULE_LOCAL_NAME.google_project_service.main[1]" "$PROJECT_ID/appengine.googleapis.com"
-terraform import "module.$MODULE_LOCAL_NAME.google_project_service.main[2]" "$PROJECT_ID/bigquery-json.googleapis.com"
+terraform import "module.$MODULE_LOCAL_NAME.google_project_service.main[2]" "$PROJECT_ID/bigquery.googleapis.com"
 terraform import "module.$MODULE_LOCAL_NAME.google_project_service.main[3]" "$PROJECT_ID/cloudbilling.googleapis.com"
 terraform import "module.$MODULE_LOCAL_NAME.google_project_service.main[4]" "$PROJECT_ID/cloudresourcemanager.googleapis.com"
 terraform import "module.$MODULE_LOCAL_NAME.google_project_service.main[5]" "$PROJECT_ID/sql-component.googleapis.com"

--- a/helpers/setup.sh
+++ b/helpers/setup.sh
@@ -137,8 +137,10 @@ gcloud services enable \
 
 if [[ "$IS_UPDATE" == "0" ]]; then
 
-    # If is an update i don't create service accout and re-download credentials
+    # Create new service accout and download credentials
     echo "Creating a new service account ${SERVICE_ACCOUNT_EMAIL} ..."
+    export FORSETI_SETUP_SERVICE_ACCOUNT_NAME="${SERVICE_ACCOUNT_NAME}"
+
     gcloud iam service-accounts \
         --project "${PROJECT_ID}" create "${SERVICE_ACCOUNT_NAME}" \
         --display-name "${SERVICE_ACCOUNT_NAME}"
@@ -148,6 +150,8 @@ if [[ "$IS_UPDATE" == "0" ]]; then
     gcloud iam service-accounts keys create "${KEY_FILE}" \
         --iam-account "${SERVICE_ACCOUNT_EMAIL}" \
         --user-output-enabled false
+
+    export GOOGLE_APPLICATION_CREDENTIALS="${KEY_FILE}"
 fi
 
 echo "Applying permissions for org $ORG_ID and project $PROJECT_ID..."

--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ locals {
   services_list = [
     "admin.googleapis.com",
     "appengine.googleapis.com",
-    "bigquery-json.googleapis.com",
+    "bigquery.googleapis.com",
     "cloudbilling.googleapis.com",
     "cloudresourcemanager.googleapis.com",
     "sql-component.googleapis.com",

--- a/modules/on_gke/main.tf
+++ b/modules/on_gke/main.tf
@@ -54,7 +54,7 @@ locals {
   services_list = [
     "admin.googleapis.com",
     "appengine.googleapis.com",
-    "bigquery-json.googleapis.com",
+    "bigquery.googleapis.com",
     "cloudbilling.googleapis.com",
     "cloudresourcemanager.googleapis.com",
     "sql-component.googleapis.com",

--- a/modules/rules/templates/rules/enabled_apis_rules.yaml
+++ b/modules/rules/templates/rules/enabled_apis_rules.yaml
@@ -21,7 +21,7 @@
 #         resource_ids:
 #           - '*'
 #     services:
-#       - 'bigquery-json.googleapis.com'
+#       - 'bigquery.googleapis.com'
 #       - 'clouddebugger.googleapis.com'
 #       - 'cloudtrace.googleapis.com'
 #       - 'compute.googleapis.com'


### PR DESCRIPTION
Resolves #469 

Screenshot showing that module 5.1.1 is downloaded and used:
<img width="1113" alt="ModuleVer" src="https://user-images.githubusercontent.com/10247435/73462371-8f4e8380-4330-11ea-8478-1ddb09ed9495.png">

Successful terraform apply:
<img width="1113" alt="Success" src="https://user-images.githubusercontent.com/10247435/73462597-ee13fd00-4330-11ea-856d-84ebdcd56d06.png">
