### PR TITLE
Use internal DNS for client -> server communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ For this module to work, you need the following APIs enabled on the Forseti proj
 | forseti-server-git-public-key-openssh | The public OpenSSH key generated to allow the Forseti Server to clone the policy library repository. |
 | forseti-server-service-account | Forseti Server service account |
 | forseti-server-storage-bucket | Forseti Server storage bucket |
+| forseti-server-vm-internal-dns | Forseti Server internal DNS |
 | forseti-server-vm-ip | Forseti Server VM private IP address |
 | forseti-server-vm-name | Forseti Server VM name |
 | suffix | The random suffix appended to Forseti resources |

--- a/examples/install_simple/README.md
+++ b/examples/install_simple/README.md
@@ -35,6 +35,7 @@ This configuration is used to simply install Forseti. It includes a full Cloud S
 | forseti-client-vm-name | Forseti Client VM name |
 | forseti-server-service-account | Forseti Server service account |
 | forseti-server-storage-bucket | Forseti Server storage bucket |
+| forseti-server-vm-internal-dns | Forseti Server internal DNS |
 | forseti-server-vm-ip | Forseti Server VM private IP address |
 | forseti-server-vm-name | Forseti Server VM name |
 | suffix | The random suffix appended to Forseti resources |

--- a/examples/install_simple/main.tf
+++ b/examples/install_simple/main.tf
@@ -36,7 +36,7 @@ provider "random" {
 }
 
 module "forseti-install-simple" {
-  source  = "../../"
+  source = "../../"
 
   project_id = var.project_id
   org_id     = var.org_id

--- a/examples/install_simple/main.tf
+++ b/examples/install_simple/main.tf
@@ -36,8 +36,7 @@ provider "random" {
 }
 
 module "forseti-install-simple" {
-  source  = "terraform-google-modules/forseti/google"
-  version = "~> 5.1"
+  source  = "../../"
 
   project_id = var.project_id
   org_id     = var.org_id

--- a/examples/install_simple/outputs.tf
+++ b/examples/install_simple/outputs.tf
@@ -19,6 +19,11 @@ output "suffix" {
   value       = module.forseti-install-simple.suffix
 }
 
+output "forseti-client-storage-bucket" {
+  description = "Forseti Client storage bucket"
+  value       = module.forseti-install-simple.forseti-client-storage-bucket
+}
+
 output "forseti-client-vm-name" {
   description = "Forseti Client VM name"
   value       = module.forseti-install-simple.forseti-client-vm-name
@@ -39,6 +44,11 @@ output "forseti-server-vm-name" {
   value       = module.forseti-install-simple.forseti-server-vm-name
 }
 
+output "forseti-server-vm-internal-dns" {
+  description = "Forseti Server internal DNS"
+  value       = module.forseti-install-simple.forseti-server-vm-internal-dns
+}
+
 output "forseti-server-vm-ip" {
   description = "Forseti Server VM private IP address"
   value       = module.forseti-install-simple.forseti-server-vm-ip
@@ -47,11 +57,6 @@ output "forseti-server-vm-ip" {
 output "forseti-server-service-account" {
   description = "Forseti Server service account"
   value       = module.forseti-install-simple.forseti-server-service-account
-}
-
-output "forseti-client-storage-bucket" {
-  description = "Forseti Client storage bucket"
-  value       = module.forseti-install-simple.forseti-client-storage-bucket
 }
 
 output "forseti-server-storage-bucket" {

--- a/examples/shared_vpc/README.md
+++ b/examples/shared_vpc/README.md
@@ -28,6 +28,7 @@ This example illustrates how to set up a Forseti installation with shared VPC.
 | forseti-client-vm-name | Forseti Client VM name |
 | forseti-server-service-account | Forseti Server service account |
 | forseti-server-storage-bucket | Forseti Server storage bucket |
+| forseti-server-vm-internal-dns | Forseti Server internal DNS |
 | forseti-server-vm-ip | Forseti Server VM private IP address |
 | forseti-server-vm-name | Forseti Server VM name |
 | network | Network where server and client will be deployed |

--- a/examples/shared_vpc/outputs.tf
+++ b/examples/shared_vpc/outputs.tf
@@ -29,6 +29,11 @@ output "network_project" {
   value       = var.network_project
 }
 
+output "forseti-server-vm-internal-dns" {
+  description = "Forseti Server internal DNS"
+  value       = module.forseti.forseti-server-vm-internal-dns
+}
+
 output "forseti-server-vm-ip" {
   description = "Forseti Server VM private IP address"
   value       = module.forseti.forseti-server-vm-ip

--- a/main.tf
+++ b/main.tf
@@ -352,5 +352,5 @@ module "client_gcs" {
 module "client_config" {
   source            = "./modules/client_config"
   client_gcs_module = module.client_gcs
-  server_address    = module.server.forseti-server-vm-ip
+  server_address    = module.server.forseti-server-vm-internal-dns
 }

--- a/modules/client/templates/scripts/forseti-client/forseti_client_startup_script.sh.tpl
+++ b/modules/client/templates/scripts/forseti-client/forseti_client_startup_script.sh.tpl
@@ -46,4 +46,3 @@ echo "${forseti_environment}" > /etc/profile.d/forseti_environment.sh | sudo sh
 
 # Download client configuration from GCS
 gsutil cp gs://${storage_bucket_name}/configs/forseti_conf_client.yaml ${forseti_client_conf_path}
-gsutil cp -r gs://${storage_bucket_name}/rules ${forseti_home}/

--- a/modules/client/templates/scripts/forseti-client/forseti_environment.sh.tpl
+++ b/modules/client/templates/scripts/forseti-client/forseti_environment.sh.tpl
@@ -1,2 +1,3 @@
 export FORSETI_HOME=${forseti_home}
 export FORSETI_CLIENT_CONFIG=${forseti_client_conf_path}
+forseti config reset &> /dev/null

--- a/modules/server/outputs.tf
+++ b/modules/server/outputs.tf
@@ -28,3 +28,8 @@ output "forseti-server-vm-name" {
   description = "Forseti Server VM name"
   value       = google_compute_instance.forseti-server.name
 }
+
+output "forseti-server-vm-internal-dns" {
+  description = "Forseti Server internal DNS"
+  value       = "${google_compute_instance.forseti-server.name}.${google_compute_instance.forseti-server.zone}.c.${var.project_id}.internal"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -70,6 +70,11 @@ output "forseti-server-storage-bucket" {
   value       = module.server_gcs.forseti-server-storage-bucket
 }
 
+output "forseti-server-vm-internal-dns" {
+  description = "Forseti Server internal DNS"
+  value       = module.server.forseti-server-vm-internal-dns
+}
+
 output "forseti-server-vm-ip" {
   description = "Forseti Server VM private IP address"
   value       = module.server.forseti-server-vm-ip

--- a/test/fixtures/install_simple/outputs.tf
+++ b/test/fixtures/install_simple/outputs.tf
@@ -33,6 +33,11 @@ output "forseti-client-service-account" {
   value       = module.forseti-install-simple.forseti-client-service-account
 }
 
+output "forseti-server-vm-internal-dns" {
+  description = "Forseti Server internal DNS"
+  value       = module.forseti-install-simple.forseti-server-vm-internal-dns
+}
+
 output "forseti-server-vm-name" {
   description = "Forseti Server VM name"
   value       = module.forseti-install-simple.forseti-server-vm-name

--- a/test/fixtures/shared_vpc/outputs.tf
+++ b/test/fixtures/shared_vpc/outputs.tf
@@ -28,6 +28,11 @@ output "network_project" {
   value       = var.network_project
 }
 
+output "forseti-server-vm-internal-dns" {
+  description = "Forseti Server internal DNS"
+  value       = module.forseti-shared-vpc.forseti-server-vm-internal-dns
+}
+
 output "forseti-server-vm-ip" {
   description = "Forseti Server VM private IP address"
   value       = module.forseti-shared-vpc.forseti-server-vm-ip

--- a/test/integration/install_simple/controls/client.rb
+++ b/test/integration/install_simple/controls/client.rb
@@ -14,7 +14,7 @@
 
 require "yaml"
 
-forseti_server_vm_ip = attribute("forseti-server-vm-ip")
+forseti_server_vm_internal_dns = attribute("forseti-server-vm-internal-dns")
 forseti_version = "2.24.0"
 
 control "client" do
@@ -25,11 +25,12 @@ control "client" do
 
   describe command("forseti config show") do
     its("exit_status") { should eq 0 }
-    its("stdout") { should match(/#{forseti_server_vm_ip}:50051/) }
+    its("stdout") { should match(/#{forseti_server_vm_internal_dns}:50051/) }
   end
 
   describe command("forseti inventory list") do
     its("exit_status") { should eq 0 }
+    its('stdout') { should_not match(/Error communicating to the Forseti server/) }
   end
 
   describe command("python3 -m pip show forseti-security|grep Version") do
@@ -41,8 +42,8 @@ control "client" do
   describe file("/home/ubuntu/forseti-security/configs/forseti_conf_client.yaml") do
     it { should exist }
 
-    it "sets the hostname to the Forseti server IP" do
-      expect(YAML.load(subject.content)).to eq("server_ip" => forseti_server_vm_ip)
+    it "sets the hostname to the Forseti server internal DNS" do
+      expect(YAML.load(subject.content)).to eq("server_ip" => forseti_server_vm_internal_dns)
     end
   end
 end

--- a/test/integration/install_simple/inspec.yml
+++ b/test/integration/install_simple/inspec.yml
@@ -51,6 +51,9 @@ attributes:
 - name: forseti-server-service-account
   required: true
   type: string
+- name: forseti-server-vm-internal-dns
+  required: true
+  type: string
 depends:
   - name: inspec-gcp
     git: https://github.com/inspec/inspec-gcp.git

--- a/test/integration/shared_vpc/controls/gcloud.rb
+++ b/test/integration/shared_vpc/controls/gcloud.rb
@@ -14,13 +14,13 @@
 
 title 'Forseti Terraform GCP Test Suite for Shared VPC setup using gcloud command'
 
-project_id              = attribute("project_id")
-forseti_server_vm_name  = attribute("forseti-server-vm-name")
-forseti_server_vm_ip    = attribute("forseti-server-vm-ip")
-forseti_client_vm_name  = attribute("forseti-client-vm-name")
-region                  = attribute("region")
-subnetwork              = attribute("subnetwork")
-network_project         = attribute("network_project")
+project_id                     = attribute("project_id")
+forseti_server_vm_name         = attribute("forseti-server-vm-name")
+forseti_server_vm_internal_dns = attribute("forseti-server-vm-internal-dns")
+forseti_client_vm_name         = attribute("forseti-client-vm-name")
+region                         = attribute("region")
+subnetwork                     = attribute("subnetwork")
+network_project                = attribute("network_project")
 
 control 'forseti-subnetwork' do
   impact 1.0
@@ -96,6 +96,6 @@ control 'forseti-command-client' do
   describe command("forseti config show") do
     its(:exit_status) { should eq 0 }
     its(:stderr) { should eq '' }
-    its(:stdout) { should match /'endpoint': '#{forseti_server_vm_ip}:50051'/ }
+    its(:stdout) { should match /'endpoint': '#{forseti_server_vm_internal_dns}:50051'/ }
   end
 end

--- a/test/integration/shared_vpc/inspec.yml
+++ b/test/integration/shared_vpc/inspec.yml
@@ -73,3 +73,6 @@ attributes:
   - name: forseti-server-service-account
     required: true
     description: "Forseti Server Service Account"
+  - name: forseti-server-vm-internal-dns
+    required: true
+    type: string


### PR DESCRIPTION
Use the internal DNS name for the Forseti server from the client, and reset the config as part of the Forseti env script. This will ensure the client always has the correct DNS/IP for the server.

Resolves #295 