### PR TITLE
Expose Cloud SQL instance IP.

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ For this module to work, you need the following APIs enabled on the Forseti proj
 | forseti-client-vm-ip | Forseti Client VM private IP address |
 | forseti-client-vm-name | Forseti Client VM name |
 | forseti-cloudsql-connection-name | Forseti CloudSQL Connection String |
+| forseti-cloudsql-instance-ip | The IP of the master CloudSQL instance |
 | forseti-cloudsql-password | CloudSQL password |
 | forseti-cloudsql-user | CloudSQL user |
 | forseti-server-git-public-key-openssh | The public OpenSSH key generated to allow the Forseti Server to clone the policy library repository. |

--- a/modules/cloudsql/outputs.tf
+++ b/modules/cloudsql/outputs.tf
@@ -24,6 +24,11 @@ output "forseti-cloudsql-instance-name" {
   value       = google_sql_database_instance.master.name
 }
 
+output "forseti-cloudsql-instance-ip" {
+  description = "The IP of the master CloudSQL instance"
+  value       = google_sql_database_instance.master.ip_address.0.ip_address
+}
+
 output "forseti-cloudsql-region" {
   description = "CloudSQL region"
   value       = var.cloudsql_region
@@ -34,7 +39,7 @@ output "forseti-cloudsql-db-name" {
   value       = var.cloudsql_db_name
 }
 
-output "forseti-clodusql-db-port" {
+output "forseti-cloudsql-db-port" {
   description = "CloudSQL database port"
   value       = "3306"
 }

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -105,7 +105,7 @@ data "template_file" "forseti_server_env" {
   vars = {
     project_id             = var.project_id
     cloudsql_db_name       = var.cloudsql_module.forseti-cloudsql-db-name
-    cloudsql_db_port       = var.cloudsql_module.forseti-clodusql-db-port
+    cloudsql_db_port       = var.cloudsql_module.forseti-cloudsql-db-port
     cloudsql_region        = var.cloudsql_module.forseti-cloudsql-region
     cloudsql_instance_name = var.cloudsql_module.forseti-cloudsql-instance-name
     cloudsql_db_user       = var.cloudsql_module.forseti-cloudsql-user

--- a/outputs.tf
+++ b/outputs.tf
@@ -39,6 +39,11 @@ output "forseti-client-vm-name" {
   value       = module.client.forseti-client-vm-name
 }
 
+output "forseti-cloudsql-instance-ip" {
+  description = "The IP of the master CloudSQL instance"
+  value       = module.cloudsql.forseti-cloudsql-instance-ip
+}
+
 output "forseti-cloudsql-connection-name" {
   description = "Forseti CloudSQL Connection String"
   value       = module.cloudsql.forseti-cloudsql-connection-name


### PR DESCRIPTION
This rule makes sure the server VM can still communicating to the SQL
instance when all egress traffic is blocked by default on the server VM.