### PR TITLE
Changes for Release 5.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,19 @@ Extending the adopted spec, each change should have a link to its corresponding 
 
 ## Unreleased
 
+## [v5.0.2] - 2020-02-24
+
+### Added
+
+- Support for Forseti v2.23.2 [#513]
+
 ## [v5.0.1] - 2020-01-31
 
 ### Added
 
 - Support for Forseti v2.23.1 [#476]
 
-## [5.0.0] - 2019-10-17
+## [v5.0.0] - 2019-10-17
 Version 5.0.0 is a backwards-incompatible release. Please see the [upgrade instructions](./docs/upgrading_to_v5.0.md) for details.
 
 ### Added
@@ -298,7 +304,9 @@ Version 4.0.0 is a backwards-incompatible release. Please see the [upgrade instr
 [v4.3.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v4.2.1...v4.3.0
 [v5.0.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v4.3.0...v5.0.0
 [v5.0.1]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v5.0.0...v5.0.1
+[v5.0.2]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v5.0.1...v5.0.2
 
+[#513]: https://github.com/forseti-security/terraform-google-forseti/pull/513
 [#476]: https://github.com/forseti-security/terraform-google-forseti/pull/476
 [#330]: https://github.com/forseti-security/terraform-google-forseti/pull/330
 [#329]: https://github.com/forseti-security/terraform-google-forseti/pull/329

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Extending the adopted spec, each change should have a link to its corresponding 
 
 ### Added
 
-- Support for Forseti v2.23.2 [#513]
+- Support for Forseti v2.23.2 [#518]
 
 ## [v5.0.1] - 2020-01-31
 
@@ -306,7 +306,7 @@ Version 4.0.0 is a backwards-incompatible release. Please see the [upgrade instr
 [v5.0.1]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v5.0.0...v5.0.1
 [v5.0.2]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v5.0.1...v5.0.2
 
-[#513]: https://github.com/forseti-security/terraform-google-forseti/pull/513
+[#518]: https://github.com/forseti-security/terraform-google-forseti/pull/518
 [#476]: https://github.com/forseti-security/terraform-google-forseti/pull/476
 [#330]: https://github.com/forseti-security/terraform-google-forseti/pull/330
 [#329]: https://github.com/forseti-security/terraform-google-forseti/pull/329

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Google Cloud Shell Walkthrough has been setup to make it easy for users who ar
 
 If you are familiar with Terraform and would like to run Terraform from a different machine, you can skip this walkthrough and move onto the [How to Deploy](#how-to-deploy) section.
 
-[![Open in Google Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fforseti-security%2Fterraform-google-forseti.git&cloudshell_git_branch=module-release-5.0.0&cloudshell_working_dir=examples/install_simple&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&cloudshell_tutorial=.%2Ftutorial.md)
+[![Open in Google Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fforseti-security%2Fterraform-google-forseti.git&cloudshell_git_branch=modulerelease502&cloudshell_working_dir=examples/install_simple&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&cloudshell_tutorial=.%2Ftutorial.md)
 
 ## How to Deploy
 In order to run this module you will need to be authenticated as a user that has access to the project and can create/authorize service accounts at both the organization and project levels. To login to GCP from a shell:
@@ -20,7 +20,7 @@ gcloud auth login
 The repository has several helper scripts that can be used with the deployment process.
 
 ```bash
-git clone --branch module-release-5.0.0 --depth 1 https://github.com/forseti-security/terraform-google-forseti.git
+git clone --branch modulerelease502 --depth 1 https://github.com/forseti-security/terraform-google-forseti.git
 ```
 
 ### Install Terraform
@@ -238,7 +238,7 @@ For this module to work, you need the following APIs enabled on the Forseti proj
 | forseti\_home | Forseti installation directory | string | `"$USER_HOME/forseti-security"` | no |
 | forseti\_repo\_url | Git repo for the Forseti installation | string | `"https://github.com/forseti-security/forseti-security"` | no |
 | forseti\_run\_frequency | Schedule of running the Forseti scans | string | `"null"` | no |
-| forseti\_version | The version of Forseti to install | string | `"v2.23.1"` | no |
+| forseti\_version | The version of Forseti to install | string | `"v2.23.2"` | no |
 | forwarding\_rule\_enabled | Forwarding rule scanner enabled. | bool | `"false"` | no |
 | forwarding\_rule\_violations\_should\_notify | Notify for forwarding rule violations | bool | `"true"` | no |
 | group\_enabled | Group scanner enabled. | bool | `"true"` | no |

--- a/docs/upgrading_to_v5.0.md
+++ b/docs/upgrading_to_v5.0.md
@@ -12,9 +12,9 @@ Following these instructions will import existing Forseti infrastructure resourc
 ### Migrating from the Python Installer
 A Cloud Shell walkthrough is provided to assist with migrating Forseti previously deployed with the Python installer.  Completing this guide will also result in a Forseti deployment upgraded to the most recent version.
 
-[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fforseti-security%2Fterraform-google-forseti.git&cloudshell_git_branch=module-release-5.0.0&cloudshell_working_dir=examples/migrate_forseti&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&cloudshell_tutorial=.%2Ftutorial.md)
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fforseti-security%2Fterraform-google-forseti.git&cloudshell_git_branch=modulerelease502&cloudshell_working_dir=examples/migrate_forseti&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&cloudshell_tutorial=.%2Ftutorial.md)
 
 ### Upgrading Forseti Deployed/Upgraded with Terraform
 A Cloud Shell walkthrough is provided to assist with upgrading Forseti previously deployed with Terraform.  Completing this guide will also result in a Forseti deployment upgraded to the most recent version.
 
-[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fforseti-security%2Fterraform-google-forseti.git&cloudshell_git_branch=module-release-5.0.0&cloudshell_working_dir=examples/upgrade_forseti_with_v5.0&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&cloudshell_tutorial=.%2Ftutorial.md)
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fforseti-security%2Fterraform-google-forseti.git&cloudshell_git_branch=modulerelease502&cloudshell_working_dir=examples/upgrade_forseti_with_v5.0&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&cloudshell_tutorial=.%2Ftutorial.md)

--- a/examples/install_simple/README.md
+++ b/examples/install_simple/README.md
@@ -2,7 +2,7 @@
 
 This configuration is used to simply install Forseti. It includes a full Cloud Shell [tutorial](./tutorial.md).
 
-[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fforseti-security%2Fterraform-google-forseti.git&cloudshell_git_branch=module-release-5.0.0&cloudshell_working_dir=examples/install_simple&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&cloudshell_tutorial=.%2Ftutorial.md)
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fforseti-security%2Fterraform-google-forseti.git&cloudshell_git_branch=modulerelease502&cloudshell_working_dir=examples/install_simple&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&cloudshell_tutorial=.%2Ftutorial.md)
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs

--- a/examples/migrate_forseti/tutorial.md
+++ b/examples/migrate_forseti/tutorial.md
@@ -144,7 +144,7 @@ to match the region where the Forseti Client VM is deployed.
 Starting with Forseti Security 2.23, Terraform will manage your server
  configuration file for you.  Configuration options will now be input
  variables that are defined in the Terraform module. Available variables
- and their default values can be found [here](https://github.com/forseti-security/terraform-google-forseti/blob/module-release-5.0.0/variables.tf).
+ and their default values can be found [here](https://github.com/forseti-security/terraform-google-forseti/blob/modulerelease502/variables.tf).
  Default values will be used if values are not explicitly added.
  This will ensure upgrading Forseti will be as easy as possible going forward.
 
@@ -186,10 +186,10 @@ to your <walkthrough-editor-select-regex
   regex="Add any Forseti Server Configuration Variables Here">main.tf</walkthrough-editor-select-regex>.
 
 ## Obtain and Run the Import Script
-This [import script](https://github.com/forseti-security/terraform-google-forseti/blob/module-release-5.0.0/helpers/import.sh) will import the Forseti GCP resources into a local state file.
+This [import script](https://github.com/forseti-security/terraform-google-forseti/blob/modulerelease502/helpers/import.sh) will import the Forseti GCP resources into a local state file.
 
 ```sh
-curl --location --remote-name https://raw.githubusercontent.com/forseti-security/terraform-google-forseti/module-release-5.0.0/helpers/import.sh
+curl --location --remote-name https://raw.githubusercontent.com/forseti-security/terraform-google-forseti/modulerelease502/helpers/import.sh
 chmod +x import.sh
 ./import.sh -h
 ```

--- a/examples/on_gke_end_to_end/README.md
+++ b/examples/on_gke_end_to_end/README.md
@@ -72,8 +72,8 @@ This script will also activate necessary APIs required for Terraform to deploy F
 | gsuite\_admin\_email | G-Suite administrator email address to manage your Forseti installation | string | n/a | yes |
 | helm\_repository\_url | The Helm repository containing the 'forseti-security' Helm charts | string | `"https://forseti-security-charts.storage.googleapis.com/release/"` | no |
 | k8s\_forseti\_namespace | The Kubernetes namespace in which to deploy Forseti. | string | `"forseti"` | no |
-| k8s\_forseti\_orchestrator\_image\_tag | The tag for the container image for the Forseti orchestrator | string | `"v2.23.1"` | no |
-| k8s\_forseti\_server\_image\_tag | The tag for the container image for the Forseti server | string | `"v2.23.1"` | no |
+| k8s\_forseti\_orchestrator\_image\_tag | The tag for the container image for the Forseti orchestrator | string | `"v2.23.2"` | no |
+| k8s\_forseti\_server\_image\_tag | The tag for the container image for the Forseti server | string | `"v2.23.2"` | no |
 | k8s\_tiller\_sa\_name | The Kubernetes Service Account used by Tiller | string | `"tiller"` | no |
 | network | The name of the VPC being created | string | `"forseti-gke-network"` | no |
 | network\_description | An optional description of the network. The resource must be recreated to modify this field. | string | `""` | no |

--- a/examples/on_gke_end_to_end/variables.tf
+++ b/examples/on_gke_end_to_end/variables.tf
@@ -111,12 +111,12 @@ variable "k8s_tiller_sa_name" {
 
 variable "k8s_forseti_orchestrator_image_tag" {
   description = "The tag for the container image for the Forseti orchestrator"
-  default     = "v2.23.1"
+  default     = "v2.23.2"
 }
 
 variable "k8s_forseti_server_image_tag" {
   description = "The tag for the container image for the Forseti server"
-  default     = "v2.23.1"
+  default     = "v2.23.2"
 }
 
 variable "network" {

--- a/examples/upgrade_forseti_with_v5.0/tutorial.md
+++ b/examples/upgrade_forseti_with_v5.0/tutorial.md
@@ -118,10 +118,10 @@ Add the following clause to the bottom of your main.tf.
 
 ## Obtain and Run the Import Script
 ### Obtain the Import Script
-This [import script](https://github.com/forseti-security/terraform-google-forseti/blob/module-release-5.0.0/helpers/import.sh) will import the Forseti GCP resources into a local state file.
+This [import script](https://github.com/forseti-security/terraform-google-forseti/blob/modulerelease502/helpers/import.sh) will import the Forseti GCP resources into a local state file.
 
 ```sh
-curl --location --remote-name https://raw.githubusercontent.com/forseti-security/terraform-google-forseti/module-release-5.0.0/helpers/import.sh
+curl --location --remote-name https://raw.githubusercontent.com/forseti-security/terraform-google-forseti/modulerelease502/helpers/import.sh
 chmod +x import.sh
 ./import.sh -h
 ```

--- a/modules/client/variables.tf
+++ b/modules/client/variables.tf
@@ -23,7 +23,7 @@ variable "project_id" {
 
 variable "forseti_version" {
   description = "The version of Forseti to install"
-  default     = "v2.23.1"
+  default     = "v2.23.2"
 }
 
 variable "forseti_repo_url" {

--- a/modules/on_gke/README.md
+++ b/modules/on_gke/README.md
@@ -79,7 +79,7 @@ This sub-module deploys Forseti on GKE.  In short, this deploys a server contain
 | forseti\_home | Forseti installation directory | string | `"$USER_HOME/forseti-security"` | no |
 | forseti\_repo\_url | Git repo for the Forseti installation | string | `"https://github.com/forseti-security/forseti-security"` | no |
 | forseti\_run\_frequency | Schedule of running the Forseti scans | string | `"null"` | no |
-| forseti\_version | The version of Forseti to install | string | `"v2.23.1"` | no |
+| forseti\_version | The version of Forseti to install | string | `"v2.23.2"` | no |
 | forwarding\_rule\_enabled | Forwarding rule scanner enabled. | bool | `"false"` | no |
 | forwarding\_rule\_violations\_should\_notify | Notify for forwarding rule violations | bool | `"true"` | no |
 | git\_sync\_image | The container image used by the config-validator git-sync side-car | string | `"gcr.io/google-containers/git-sync"` | no |
@@ -113,9 +113,9 @@ This sub-module deploys Forseti on GKE.  In short, this deploys a server contain
 | k8s\_config\_validator\_image\_tag | The tag for the config-validator image. | string | `"latest"` | no |
 | k8s\_forseti\_namespace | The Kubernetes namespace in which to deploy Forseti. | string | `"forseti"` | no |
 | k8s\_forseti\_orchestrator\_image | The container image for the Forseti orchestrator | string | `"gcr.io/forseti-containers/forseti"` | no |
-| k8s\_forseti\_orchestrator\_image\_tag | The tag for the container image for the Forseti orchestrator | string | `"v2.23.1"` | no |
+| k8s\_forseti\_orchestrator\_image\_tag | The tag for the container image for the Forseti orchestrator | string | `"v2.23.2"` | no |
 | k8s\_forseti\_server\_image | The container image for the Forseti server | string | `"gcr.io/forseti-containers/forseti"` | no |
-| k8s\_forseti\_server\_image\_tag | The tag for the container image for the Forseti server | string | `"v2.23.1"` | no |
+| k8s\_forseti\_server\_image\_tag | The tag for the container image for the Forseti server | string | `"v2.23.2"` | no |
 | k8s\_forseti\_server\_ingress\_cidr | If network_policy is true, k8s_forseti_server_ingress_cidr will restrict connections to the Forseti Server service from the CIDR's specified | string | `""` | no |
 | k8s\_tiller\_sa\_name | The Kubernetes Service Account used by Tiller | string | `"tiller"` | no |
 | ke\_scanner\_enabled | KE scanner enabled. | bool | `"false"` | no |

--- a/modules/on_gke/variables.tf
+++ b/modules/on_gke/variables.tf
@@ -80,7 +80,7 @@ variable "gsuite_admin_email" {
 
 variable "forseti_version" {
   description = "The version of Forseti to install"
-  default     = "v2.23.1"
+  default     = "v2.23.2"
 }
 
 variable "forseti_repo_url" {
@@ -879,7 +879,7 @@ variable "k8s_forseti_orchestrator_image" {
 
 variable "k8s_forseti_orchestrator_image_tag" {
   description = "The tag for the container image for the Forseti orchestrator"
-  default     = "v2.23.1"
+  default     = "v2.23.2"
 }
 
 variable "k8s_forseti_server_image" {
@@ -889,7 +889,7 @@ variable "k8s_forseti_server_image" {
 
 variable "k8s_forseti_server_image_tag" {
   description = "The tag for the container image for the Forseti server"
-  default     = "v2.23.1"
+  default     = "v2.23.2"
 }
 
 variable "k8s_forseti_server_ingress_cidr" {

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -55,6 +55,8 @@ locals {
   network_interface = local.network_interface_base[var.server_private ? "private" : "public"]
 
   forseti_run_frequency = var.forseti_run_frequency == null ? "${random_integer.random_minute.result} */2 * * *" : var.forseti_run_frequency
+
+  git_sync_public_ssh_key = length(tls_private_key.policy_library_sync_ssh) == 1 ? tls_private_key.policy_library_sync_ssh[0].public_key_openssh : ""
 }
 
 #-------------------#

--- a/modules/server/outputs.tf
+++ b/modules/server/outputs.tf
@@ -16,7 +16,7 @@
 
 output "forseti-server-git-public-key-openssh" {
   description = "The public OpenSSH key generated to allow the Forseti Server to clone the policy library repository."
-  value       = tls_private_key.policy_library_sync_ssh[0].public_key_openssh
+  value       = local.git_sync_public_ssh_key
 }
 
 output "forseti-server-vm-ip" {

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -23,7 +23,7 @@ variable "project_id" {
 
 variable "forseti_version" {
   description = "The version of Forseti to install"
-  default     = "v2.23.1"
+  default     = "v2.23.2"
 }
 
 variable "forseti_repo_url" {

--- a/test/integration/simple_example/controls/client.rb
+++ b/test/integration/simple_example/controls/client.rb
@@ -15,7 +15,7 @@
 require "yaml"
 
 forseti_server_vm_ip = attribute("forseti-server-vm-ip")
-forseti_version = "2.23.1"
+forseti_version = "2.23.2"
 
 control "client" do
   title "Forseti client instance resources"

--- a/test/integration/simple_example/controls/server.rb
+++ b/test/integration/simple_example/controls/server.rb
@@ -14,7 +14,7 @@
 
 require "yaml"
 
-forseti_version = "2.23.1"
+forseti_version = "2.23.2"
 
 control "server" do
   title "Forseti server instance resources"

--- a/variables.tf
+++ b/variables.tf
@@ -28,7 +28,7 @@ variable "gsuite_admin_email" {
 
 variable "forseti_version" {
   description = "The version of Forseti to install"
-  default     = "v2.23.1"
+  default     = "v2.23.2"
 }
 
 variable "forseti_repo_url" {


### PR DESCRIPTION
Update Forseti version from 2.23.1 to 2.23.2. Backport issue resolved in 5.1 related to the public ssh key used for git-sync; this issue does not exist while using Terraform 0.12.6, but is reproduced with more recent versions of Terraform.

Resolves #517 