### PR TITLE
Input for the Policy Library check of the CV scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ For this module to work, you need the following APIs enabled on the Forseti proj
 | storage\_bucket\_location | GCS storage bucket location | string | `"us-central1"` | no |
 | storage\_disable\_polling | Whether to disable polling for Storage API | bool | `"false"` | no |
 | subnetwork | The VPC subnetwork where the Forseti client and server will be created | string | `"default"` | no |
+| verify\_policy\_library | Verify the Policy Library is setup correctly for the Config Validator scanner | bool | `"true"` | no |
 | violations\_slack\_webhook | Slack webhook for any violation. Will apply to all scanner violation notifiers. | string | `""` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -332,6 +332,7 @@ module "server_config" {
   cscc_violations_enabled                             = var.cscc_violations_enabled
   cscc_source_id                                      = var.cscc_source_id
   rules_path                                          = var.rules_path
+  verify_policy_library                               = var.verify_policy_library
 
   groups_settings_max_calls                = var.groups_settings_max_calls
   groups_settings_period                   = var.groups_settings_period

--- a/modules/on_gke/README.md
+++ b/modules/on_gke/README.md
@@ -175,6 +175,7 @@ This sub-module deploys Forseti on GKE.  In short, this deploys a server contain
 | storage\_bucket\_location | GCS storage bucket location | string | `"us-central1"` | no |
 | storage\_disable\_polling | Whether to disable polling for Storage API | bool | `"false"` | no |
 | subnetwork | The VPC subnetwork where the Forseti client and server will be created | string | `"default"` | no |
+| verify\_policy\_library | Verify the Policy Library is setup correctly for the Config Validator scanner | bool | `"false"` | no |
 | violations\_slack\_webhook | Slack webhook for any violation. Will apply to all scanner violation notifiers. | string | `""` | no |
 
 ## Outputs

--- a/modules/on_gke/main.tf
+++ b/modules/on_gke/main.tf
@@ -640,6 +640,7 @@ module "server_config" {
   violations_slack_webhook                            = var.violations_slack_webhook
   cscc_violations_enabled                             = var.cscc_violations_enabled
   cscc_source_id                                      = var.cscc_source_id
+  verify_policy_library                               = var.verify_policy_library
 
   groups_settings_max_calls                = var.groups_settings_max_calls
   groups_settings_period                   = var.groups_settings_period

--- a/modules/on_gke/variables.tf
+++ b/modules/on_gke/variables.tf
@@ -517,6 +517,12 @@ variable "service_account_key_enabled" {
   default     = true
 }
 
+variable "verify_policy_library" {
+  description = "Verify the Policy Library is setup correctly for the Config Validator scanner"
+  type        = bool
+  default     = false
+}
+
 #--------------------------------#
 # Forseti server config notifier #
 #--------------------------------#

--- a/modules/server_config/main.tf
+++ b/modules/server_config/main.tf
@@ -162,6 +162,8 @@ data "template_file" "forseti_server_config" {
     AUDIT_LOGGING_VIOLATIONS_SHOULD_NOTIFY              = var.audit_logging_violations_should_notify
     VIOLATIONS_SLACK_WEBHOOK                            = var.violations_slack_webhook
     EXCLUDED_RESOURCES                                  = local.excluded_resources
+    VERIFY_POLICY_LIBRARY                               = var.verify_policy_library
+
     # CSCC notifications
     CSCC_VIOLATIONS_ENABLED = var.cscc_violations_enabled
     CSCC_SOURCE_ID          = var.cscc_source_id

--- a/modules/server_config/templates/configs/forseti_conf_server.yaml.tpl
+++ b/modules/server_config/templates/configs/forseti_conf_server.yaml.tpl
@@ -237,6 +237,7 @@ scanner:
           enabled: ${BUCKET_ACL_ENABLED}
         - name: config_validator
           enabled: ${CONFIG_VALIDATOR_ENABLED}
+          verify_policy_library: ${VERIFY_POLICY_LIBRARY}
         - name: cloudsql_acl
           enabled: ${CLOUDSQL_ACL_ENABLED}
         - name: enabled_apis

--- a/modules/server_config/variables.tf
+++ b/modules/server_config/variables.tf
@@ -426,6 +426,12 @@ variable "service_account_key_enabled" {
   default     = "true"
 }
 
+variable "verify_policy_library" {
+  description = "Verify the Policy Library is setup correctly for the Config Validator scanner"
+  type        = bool
+  default     = true
+}
+
 #-------------------------#
 # Forseti config notifier #
 #-------------------------#

--- a/test/integration/install_simple/controls/server.rb
+++ b/test/integration/install_simple/controls/server.rb
@@ -258,6 +258,14 @@ control "server" do
         expect(config["scanner"]["scanners"]).to include("name" => "cloudsql_acl", "enabled" => true)
       end
 
+      it "configures config_validator_enabled" do
+        expect(config["scanner"]["scanners"]).to include("name" => "config_validator", "enabled" => false)
+      end
+
+      it "configures verify_policy_library_enabled" do
+        expect(config["scanner"]["scanners"]).to include("name" => "config_validator", "verify_policy_library" => true)
+      end
+
       it "configures enabled_apis_enabled" do
         expect(config["scanner"]["scanners"]).to include("name" => "enabled_apis", "enabled" => false)
       end

--- a/test/integration/install_simple/controls/server.rb
+++ b/test/integration/install_simple/controls/server.rb
@@ -259,11 +259,7 @@ control "server" do
       end
 
       it "configures config_validator_enabled" do
-        expect(config["scanner"]["scanners"]).to include("name" => "config_validator", "enabled" => false)
-      end
-
-      it "configures config_validator_verify_policy_library" do
-        expect(config["scanner"]["scanners"]).to include("name" => "config_validator", "verify_policy_library" => true)
+        expect(config["scanner"]["scanners"]).to include("name" => "config_validator", "enabled" => false, "verify_policy_library" => true)
       end
 
       it "configures enabled_apis_enabled" do

--- a/test/integration/install_simple/controls/server.rb
+++ b/test/integration/install_simple/controls/server.rb
@@ -262,7 +262,7 @@ control "server" do
         expect(config["scanner"]["scanners"]).to include("name" => "config_validator", "enabled" => false)
       end
 
-      it "configures verify_policy_library_enabled" do
+      it "configures config_validator_verify_policy_library" do
         expect(config["scanner"]["scanners"]).to include("name" => "config_validator", "verify_policy_library" => true)
       end
 

--- a/variables.tf
+++ b/variables.tf
@@ -571,6 +571,12 @@ variable "rules_path" {
   default     = "/home/ubuntu/forseti-security/rules"
 }
 
+variable "verify_policy_library" {
+  description = "Verify the Policy Library is setup correctly for the Config Validator scanner"
+  type        = bool
+  default     = true
+}
+
 #--------------------------------#
 # Forseti server config notifier #
 #--------------------------------#


### PR DESCRIPTION
Added input variable to control whether or not the CV scanner will verify the Policy Library is setup correctly. We only want this to run on GCE. Corresponding [Forseti PR](https://github.com/forseti-security/forseti-security/pull/3678) has been merged to use this new server config attribute.

Related to [Forseti issue #3630](https://github.com/forseti-security/forseti-security/issues/3630).