### PR TITLE
Allow user config on GCS bucket's storage class and Cloud SQL's availability type

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ For this module to work, you need the following APIs enabled on the Forseti proj
 | cloudbilling\_period | The period of max calls for the Cloud Billing API (in seconds) | string | `"1.2"` | no |
 | cloudsql\_acl\_enabled | Cloud SQL scanner enabled. | bool | `"true"` | no |
 | cloudsql\_acl\_violations\_should\_notify | Notify for CloudSQL ACL violations | bool | `"true"` | no |
+| cloudsql\_availability\_type | Whether instance should be set up for high availability (REGIONAL) or single zone (ZONAL). | string | `"null"` | no |
 | cloudsql\_db\_name | CloudSQL database name | string | `"forseti_security"` | no |
 | cloudsql\_db\_password | CloudSQL database password | string | `""` | no |
 | cloudsql\_db\_port | CloudSQL database port | string | `"3306"` | no |
@@ -330,6 +331,7 @@ For this module to work, you need the following APIs enabled on the Forseti proj
 | sqladmin\_disable\_polling | Whether to disable polling for SQL Admin API | bool | `"false"` | no |
 | sqladmin\_max\_calls | Maximum calls that can be made to SQL Admin API | string | `"1"` | no |
 | sqladmin\_period | The period of max calls for the SQL Admin API (in seconds) | string | `"1.1"` | no |
+| storage\_bucket\_class | GCS storage bucket storage class. Supported values include: STANDARD, MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE | string | `"STANDARD"` | no |
 | storage\_bucket\_location | GCS storage bucket location | string | `"us-central1"` | no |
 | storage\_disable\_polling | Whether to disable polling for Storage API | bool | `"false"` | no |
 | subnetwork | The VPC subnetwork where the Forseti client and server will be created | string | `"default"` | no |

--- a/main.tf
+++ b/main.tf
@@ -181,6 +181,7 @@ module "cloudsql" {
   cloudsql_password          = var.cloudsql_db_password
   cloudsql_private           = var.cloudsql_private
   cloudsql_region            = var.cloudsql_region
+  cloudsql_availability_type = var.cloudsql_availability_type
   cloudsql_type              = var.cloudsql_type
   cloudsql_user              = var.cloudsql_db_user
   cloudsql_user_host         = var.cloudsql_user_host
@@ -210,6 +211,7 @@ module "server_gcs" {
   bucket_cai_lifecycle_age = var.bucket_cai_lifecycle_age
   enable_cai_bucket        = var.enable_cai_bucket
   storage_bucket_location  = var.storage_bucket_location
+  storage_bucket_class     = var.storage_bucket_class
   services                 = google_project_service.main.*.service
   suffix                   = local.random_hash
 }
@@ -353,6 +355,7 @@ module "client_gcs" {
   client_enabled          = var.client_enabled
   project_id              = var.project_id
   storage_bucket_location = var.storage_bucket_location
+  storage_bucket_class    = var.storage_bucket_class
   suffix                  = local.random_hash
 
   services = google_project_service.main.*.service

--- a/modules/client_gcs/main.tf
+++ b/modules/client_gcs/main.tf
@@ -28,6 +28,7 @@ resource "google_storage_bucket" "client_config" {
   count              = var.client_enabled ? 1 : 0
   name               = local.client_bucket_name
   location           = var.storage_bucket_location
+  storage_class      = var.storage_bucket_class
   project            = var.project_id
   force_destroy      = true
   bucket_policy_only = true

--- a/modules/client_gcs/variables.tf
+++ b/modules/client_gcs/variables.tf
@@ -39,6 +39,11 @@ variable "storage_bucket_location" {
   default     = "us-central1"
 }
 
+variable "storage_bucket_class" {
+  description = "GCS storage bucket storage class. Supported values include: STANDARD, MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE"
+  default     = "STANDARD"
+}
+
 variable "services" {
   description = "An artificial dependency to bypass #10462"
   type        = list(string)

--- a/modules/cloudsql/main.tf
+++ b/modules/cloudsql/main.tf
@@ -71,6 +71,7 @@ resource "google_sql_database_instance" "master" {
     tier              = var.cloudsql_type
     activation_policy = "ALWAYS"
     disk_size         = var.cloudsql_disk_size
+    availability_type = var.cloudsql_availability_type
 
     database_flags {
       name  = "net_write_timeout"

--- a/modules/cloudsql/variables.tf
+++ b/modules/cloudsql/variables.tf
@@ -94,3 +94,8 @@ variable "cloudsql_password" {
   description = "CloudSQL password"
   default     = ""
 }
+
+variable "cloudsql_availability_type" {
+  description = "Whether instance should be set up for high availability (REGIONAL) or single zone (ZONAL)."
+  default     = null
+}

--- a/modules/server_gcs/main.tf
+++ b/modules/server_gcs/main.tf
@@ -31,6 +31,7 @@ resource "google_storage_bucket" "server_config" {
   name               = local.server_bucket_name
   location           = var.storage_bucket_location
   project            = var.project_id
+  storage_class      = var.storage_bucket_class
   force_destroy      = true
   bucket_policy_only = true
 
@@ -42,6 +43,7 @@ resource "google_storage_bucket" "cai_export" {
   name               = local.storage_cai_bucket_name
   location           = var.bucket_cai_location
   project            = var.project_id
+  storage_class      = var.storage_bucket_class
   force_destroy      = true
   bucket_policy_only = true
 

--- a/modules/server_gcs/variables.tf
+++ b/modules/server_gcs/variables.tf
@@ -42,6 +42,11 @@ variable "storage_bucket_location" {
   default     = "us-central1"
 }
 
+variable "storage_bucket_class" {
+  description = "GCS storage bucket storage class. Supported values include: STANDARD, MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE"
+  default     = "STANDARD"
+}
+
 variable "bucket_cai_location" {
   description = "GCS CAI storage bucket location"
   default     = "us-central1"
@@ -51,6 +56,8 @@ variable "bucket_cai_lifecycle_age" {
   description = "GCS CAI lifecycle age value"
   default     = "14"
 }
+
+
 
 #-------#
 # Flags #

--- a/modules/server_gcs/variables.tf
+++ b/modules/server_gcs/variables.tf
@@ -57,8 +57,6 @@ variable "bucket_cai_lifecycle_age" {
   default     = "14"
 }
 
-
-
 #-------#
 # Flags #
 #-------#

--- a/variables.tf
+++ b/variables.tf
@@ -876,6 +876,11 @@ variable "cloudsql_disk_size" {
   default     = "25"
 }
 
+variable "cloudsql_availability_type" {
+  description = "Whether instance should be set up for high availability (REGIONAL) or single zone (ZONAL)."
+  default     = null
+}
+
 variable "cloudsql_private" {
   description = "Whether to enable private network and not to create public IP for CloudSQL Instance"
   default     = false
@@ -918,6 +923,11 @@ variable "cloudsql_db_password" {
 variable "storage_bucket_location" {
   description = "GCS storage bucket location"
   default     = "us-central1"
+}
+
+variable "storage_bucket_class" {
+  description = "GCS storage bucket storage class. Supported values include: STANDARD, MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE"
+  default     = "STANDARD"
 }
 
 variable "bucket_cai_location" {


### PR DESCRIPTION
This PR exposes `storage_class` (GCS bucket) and `availability_type` (Cloud SQL) all the way to the top. 

See:
- https://www.terraform.io/docs/providers/google/r/storage_bucket.html#storage_class
- https://www.terraform.io/docs/providers/google/r/sql_database_instance.html#availability_type

Hence, 2 new optional variables are introduced: 
- `storage_bucket_class`
- `cloudsql_availability_type`.

Example:-

```
module "forseti" {
  source                     = "..."

  // 2 new variables	
  cloudsql_availability_type = "REGIONAL"
  storage_bucket_class       = "MULTI_REGIONAL"
}
```

No tests are added because it's fairly straightforward. 

Thank you.