### PR TITLE
Standard changes for release 5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Extending the adopted spec, each change should have a link to its corresponding pull request appended.
 
-## [Unreleased] - TBD
+## [v5.2.0] - 2020-03-18
 
 ### Added
 - Configure firewall rules in support of private Client and Server [#391]
@@ -24,6 +24,20 @@ Extending the adopted spec, each change should have a link to its corresponding 
 - Update version in README [#426]
 - Removed simple_example [#444]
 - Create CONTRIBUTORS file [#454]
+- Expose Cloud SQL instance IP [#483]
+- CAI - Add k8s.io/Service resource [#485]
+- Ability to configure shielded instance config [#488]
+- Create Governance file [#535]
+- Update stale bot [#534]
+- Support Bring-Your-Own Service Accounts [#546]
+- Automated roles and APIs needed for Forseti on-GKE deployment [#498]
+- Bump google provider version to 3.7 [#502]
+- Update Cloud shell tutorial and other links to point to modulerelease512 [#503]
+- Ability to exclude client VM [#504]
+- Added functionality to enable/disable role scanner [#526]
+- Input for the Policy Library check of the CV scanner [#529]
+- Update stale.yml [#534]
+- Create GOVERNANCE.md [#535]
 
 ### Fixed
 - Fix space in Location Rules template [#392]
@@ -36,6 +50,26 @@ Extending the adopted spec, each change should have a link to its corresponding 
 - Fix validate error [#449]
 - Increased open files limit to fix OSError: [Errno 24] Too many open files [#450]
 - Sync policy library with gsutil rsync [#463]
+- Fix security reviewer role name [#466]
+- Fix cloudsql password [#472]
+- Add service usage service resource [#473]
+- Use internal DNS for client -> server communication [#482]
+- Pin helm provider version to 0.10.* for Helm 2 [#495]
+- Fix GKE example [#508]
+- manage_rules_enabled=false should not prevent Forseti service from starting [#512]
+- Corrected description for blacklist scanner [#525]
+
+## [v5.1.3] - 2020-02-25
+
+### Added
+
+- Support for Forseti v2.24.2 [#524]
+
+## [v5.1.2] - 2020-02-07
+
+### Added
+
+- Support for Forseti v2.24.1 [#499]
 
 ## [v5.1.1] - 2020-01-14
 
@@ -43,7 +77,7 @@ Extending the adopted spec, each change should have a link to its corresponding 
 - Update the Bigquery api to the new name
 
 
-## [5.1.0] - 2019-11-15
+## [v5.1.0] - 2019-11-15
 
 ### Added
 - Support for Forseti v2.24.0 [#386]
@@ -68,7 +102,19 @@ Extending the adopted spec, each change should have a link to its corresponding 
 ### Removed
 - Issue templates [#365]
 
-## [5.0.0] - 2019-10-17
+## [v5.0.2] - 2020-02-24
+
+### Added
+
+- Support for Forseti v2.23.2 [#518]
+
+## [v5.0.1] - 2020-01-31
+
+### Added
+
+- Support for Forseti v2.23.1 [#476]
+
+## [v5.0.0] - 2019-10-17
 Version 5.0.0 is a backwards-incompatible release. Please see the [upgrade instructions](./docs/upgrading_to_v5.0.md) for details.
 
 ### Added
@@ -326,7 +372,7 @@ Version 4.0.0 is a backwards-incompatible release. Please see the [upgrade instr
 ### ADDED
 - This is the initial release of the Forseti module.
 
-[Unreleased]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v5.1.1...HEAD
+[Unreleased]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v5.2.0...HEAD
 [v0.1.0]: https://github.com/terraform-google-modules/terraform-google-forseti/releases/tag/v0.1.0
 [v1.0.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v0.1.0...v1.0.0
 [v1.1.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v1.0.0...v1.1.0
@@ -350,9 +396,35 @@ Version 4.0.0 is a backwards-incompatible release. Please see the [upgrade instr
 [v4.2.1]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v4.1.0...v4.2.1
 [v4.3.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v4.2.1...v4.3.0
 [v5.0.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v4.3.0...v5.0.0
-[v5.1.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v5.0.0...v5.1.0
+[v5.0.1]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v5.0.0...v5.0.1
+[v5.0.2]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v5.0.1...v5.0.2
+[v5.1.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v5.0.2...v5.1.0
 [v5.1.1]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v5.1.0...v5.1.1
+[v5.1.2]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v5.1.1...v5.1.2
+[v5.1.3]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v5.1.2...v5.1.3
+[v5.2.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v5.1.3...v5.2.0
 
+[#546]: https://github.com/forseti-security/terraform-google-forseti/pull/546
+[#535]: https://github.com/forseti-security/terraform-google-forseti/pull/535
+[#534]: https://github.com/forseti-security/terraform-google-forseti/pull/534
+[#529]: https://github.com/forseti-security/terraform-google-forseti/pull/529
+[#526]: https://github.com/forseti-security/terraform-google-forseti/pull/526
+[#525]: https://github.com/forseti-security/terraform-google-forseti/pull/525
+[#518]: https://github.com/forseti-security/terraform-google-forseti/pull/518
+[#512]: https://github.com/forseti-security/terraform-google-forseti/pull/512
+[#508]: https://github.com/forseti-security/terraform-google-forseti/pull/508
+[#508]: https://github.com/forseti-security/terraform-google-forseti/pull/504
+[#508]: https://github.com/forseti-security/terraform-google-forseti/pull/503
+[#502]: https://github.com/forseti-security/terraform-google-forseti/pull/502
+[#498]: https://github.com/forseti-security/terraform-google-forseti/pull/498
+[#495]: https://github.com/forseti-security/terraform-google-forseti/pull/495
+[#488]: https://github.com/forseti-security/terraform-google-forseti/pull/488
+[#485]: https://github.com/forseti-security/terraform-google-forseti/pull/485
+[#483]: https://github.com/forseti-security/terraform-google-forseti/pull/483
+[#482]: https://github.com/forseti-security/terraform-google-forseti/pull/482
+[#476]: https://github.com/forseti-security/terraform-google-forseti/pull/476
+[#472]: https://github.com/forseti-security/terraform-google-forseti/pull/472
+[#466]: https://github.com/forseti-security/terraform-google-forseti/pull/466
 [#463]: https://github.com/forseti-security/terraform-google-forseti/pull/463
 [#454]: https://github.com/forseti-security/terraform-google-forseti/pull/454
 [#450]: https://github.com/forseti-security/terraform-google-forseti/pull/450

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Google Cloud Shell Walkthrough has been setup to make it easy for users who ar
 
 If you are familiar with Terraform and would like to run Terraform from a different machine, you can skip this walkthrough and move onto the [How to Deploy](#how-to-deploy) section.
 
-[![Open in Google Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fforseti-security%2Fterraform-google-forseti.git&cloudshell_git_branch=modulerelease512&cloudshell_working_dir=examples/install_simple&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&cloudshell_tutorial=.%2Ftutorial.md)
+[![Open in Google Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fforseti-security%2Fterraform-google-forseti.git&cloudshell_git_branch=modulerelease520&cloudshell_working_dir=examples/install_simple&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&cloudshell_tutorial=.%2Ftutorial.md)
 
 ## How to Deploy
 In order to run this module you will need to be authenticated as a user that has access to the project and can create/authorize service accounts at both the organization and project levels. To login to GCP from a shell:
@@ -20,7 +20,7 @@ gcloud auth login
 The repository has several helper scripts that can be used with the deployment process.
 
 ```bash
-git clone --branch modulerelease512 --depth 1 https://github.com/forseti-security/terraform-google-forseti.git
+git clone --branch modulerelease520 --depth 1 https://github.com/forseti-security/terraform-google-forseti.git
 ```
 
 ### Install Terraform
@@ -244,7 +244,7 @@ For this module to work, you need the following APIs enabled on the Forseti proj
 | forseti\_home | Forseti installation directory | string | `"$USER_HOME/forseti-security"` | no |
 | forseti\_repo\_url | Git repo for the Forseti installation | string | `"https://github.com/forseti-security/forseti-security"` | no |
 | forseti\_run\_frequency | Schedule of running the Forseti scans | string | `"null"` | no |
-| forseti\_version | The version of Forseti to install | string | `"v2.24.0"` | no |
+| forseti\_version | The version of Forseti to install | string | `"v2.25.0"` | no |
 | forwarding\_rule\_enabled | Forwarding rule scanner enabled. | bool | `"false"` | no |
 | forwarding\_rule\_violations\_should\_notify | Notify for forwarding rule violations | bool | `"true"` | no |
 | group\_enabled | Group scanner enabled. | bool | `"true"` | no |

--- a/build/int-release.cloudbuild.yaml
+++ b/build/int-release.cloudbuild.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ steps:
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge']
   env:
-    - 'TF_VAR_forseti_version=$_FORSETI_VERSION'
+  - 'TF_VAR_forseti_version=$_FORSETI_VERSION'
 - id: verify
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify']
@@ -41,4 +41,4 @@ tags:
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
   _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.4.6'
-  _FORSETI_VERSION: 'master'
+  _FORSETI_VERSION: 'v2.25.0'

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-timeout: 7200s
+timeout: 10800s
 steps:
 - id: prepare
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -27,8 +27,6 @@ steps:
 - id: converge
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge']
-  env:
-    - 'TF_VAR_forseti_version=$_FORSETI_VERSION'
 - id: verify
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify']
@@ -41,4 +39,3 @@ tags:
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
   _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.4.6'
-  _FORSETI_VERSION: 'master'

--- a/examples/install_simple/README.md
+++ b/examples/install_simple/README.md
@@ -2,7 +2,7 @@
 
 This configuration is used to simply install Forseti. It includes a full Cloud Shell [tutorial](./tutorial.md).
 
-[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fforseti-security%2Fterraform-google-forseti.git&cloudshell_git_branch=modulerelease512&cloudshell_working_dir=examples/install_simple&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&cloudshell_tutorial=.%2Ftutorial.md)
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fforseti-security%2Fterraform-google-forseti.git&cloudshell_git_branch=modulerelease520&cloudshell_working_dir=examples/install_simple&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&cloudshell_tutorial=.%2Ftutorial.md)
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
@@ -12,7 +12,7 @@ This configuration is used to simply install Forseti. It includes a full Cloud S
 | domain | The domain associated with the GCP Organization ID | string | n/a | yes |
 | forseti\_email\_recipient | Forseti email recipient. | string | `""` | no |
 | forseti\_email\_sender | Forseti email sender. | string | `""` | no |
-| forseti\_version | The version of Forseti to install | string | `"v2.24.0"` | no |
+| forseti\_version | The version of Forseti to install | string | `"v2.25.0"` | no |
 | gsuite\_admin\_email | The email of a GSuite super admin, used for pulling user directory information *and* sending notifications. | string | n/a | yes |
 | instance\_metadata | Metadata key/value pairs to make available from within the client and server instances. | map(string) | `<map>` | no |
 | instance\_tags | Tags to assign the client and server instances. | list(string) | `<list>` | no |

--- a/examples/install_simple/variables.tf
+++ b/examples/install_simple/variables.tf
@@ -65,7 +65,7 @@ variable "forseti_email_recipient" {
 
 variable "forseti_version" {
   description = "The version of Forseti to install"
-  default     = "v2.24.0"
+  default     = "v2.25.0"
 }
 
 variable "region" {

--- a/examples/migrate_forseti/tutorial.md
+++ b/examples/migrate_forseti/tutorial.md
@@ -160,7 +160,7 @@ to match the region where the CAI GCS bucket is deployed.
 Starting with Forseti Security 2.23, Terraform will manage your server
  configuration file for you.  Configuration options will now be input
  variables that are defined in the Terraform module. Available variables
- and their default values can be found [here](https://github.com/forseti-security/terraform-google-forseti/blob/modulerelease512/variables.tf).
+ and their default values can be found [here](https://github.com/forseti-security/terraform-google-forseti/blob/modulerelease520/variables.tf).
  Default values will be used if values are not explicitly added.
  This will ensure upgrading Forseti will be as easy as possible going forward.
 
@@ -202,10 +202,10 @@ to your <walkthrough-editor-select-regex
   regex="Add any Forseti Server Configuration Variables Here">main.tf</walkthrough-editor-select-regex>.
 
 ## Obtain and Run the Import Script
-This [import script](https://github.com/forseti-security/terraform-google-forseti/blob/modulerelease512/helpers/import.sh) will import the Forseti GCP resources into a local state file.
+This [import script](https://github.com/forseti-security/terraform-google-forseti/blob/modulerelease520/helpers/import.sh) will import the Forseti GCP resources into a local state file.
 
 ```sh
-curl --location --remote-name https://raw.githubusercontent.com/forseti-security/terraform-google-forseti/modulerelease512/helpers/import.sh
+curl --location --remote-name https://raw.githubusercontent.com/forseti-security/terraform-google-forseti/modulerelease520/helpers/import.sh
 chmod +x import.sh
 ./import.sh -h
 ```

--- a/examples/on_gke_end_to_end/README.md
+++ b/examples/on_gke_end_to_end/README.md
@@ -76,8 +76,8 @@ This script will also activate necessary APIs required for Terraform to deploy F
 | gsuite\_admin\_email | G-Suite administrator email address to manage your Forseti installation | string | n/a | yes |
 | helm\_repository\_url | The Helm repository containing the 'forseti-security' Helm charts | string | `"https://forseti-security-charts.storage.googleapis.com/release/"` | no |
 | k8s\_forseti\_namespace | The Kubernetes namespace in which to deploy Forseti. | string | `"forseti"` | no |
-| k8s\_forseti\_orchestrator\_image\_tag | The tag for the container image for the Forseti orchestrator | string | `"v2.24.0"` | no |
-| k8s\_forseti\_server\_image\_tag | The tag for the container image for the Forseti server | string | `"v2.24.0"` | no |
+| k8s\_forseti\_orchestrator\_image\_tag | The tag for the container image for the Forseti orchestrator | string | `"v2.25.0"` | no |
+| k8s\_forseti\_server\_image\_tag | The tag for the container image for the Forseti server | string | `"v2.25.0"` | no |
 | k8s\_tiller\_sa\_name | The Kubernetes Service Account used by Tiller | string | `"tiller"` | no |
 | kubernetes\_version | The Kubernetes version of the masters. If set to 'latest' it will pull latest available version in the selected region. | string | `"1.14.10-gke.17"` | no |
 | network | The name of the VPC being created | string | `"forseti-gke-network"` | no |

--- a/examples/on_gke_end_to_end/variables.tf
+++ b/examples/on_gke_end_to_end/variables.tf
@@ -126,12 +126,12 @@ variable "k8s_tiller_sa_name" {
 
 variable "k8s_forseti_orchestrator_image_tag" {
   description = "The tag for the container image for the Forseti orchestrator"
-  default     = "v2.24.0"
+  default     = "v2.25.0"
 }
 
 variable "k8s_forseti_server_image_tag" {
   description = "The tag for the container image for the Forseti server"
-  default     = "v2.24.0"
+  default     = "v2.25.0"
 }
 
 variable "kubernetes_version" {

--- a/examples/shared_vpc/README.md
+++ b/examples/shared_vpc/README.md
@@ -8,7 +8,7 @@ This example illustrates how to set up a Forseti installation with shared VPC.
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | domain | Organization domain | string | n/a | yes |
-| forseti\_version | The version of Forseti to install | string | `"v2.24.0"` | no |
+| forseti\_version | The version of Forseti to install | string | `"v2.25.0"` | no |
 | gsuite\_admin\_email | G Suite admin email | string | n/a | yes |
 | instance\_metadata | Metadata key/value pairs to make available from within the client and server instances. | map(string) | `<map>` | no |
 | network | Name of the shared VPC | string | n/a | yes |

--- a/examples/shared_vpc/variables.tf
+++ b/examples/shared_vpc/variables.tf
@@ -16,7 +16,7 @@
 
 variable "forseti_version" {
   description = "The version of Forseti to install"
-  default     = "v2.24.0"
+  default     = "v2.25.0"
 }
 
 variable "network_project" {

--- a/modules/client/variables.tf
+++ b/modules/client/variables.tf
@@ -23,7 +23,7 @@ variable "project_id" {
 
 variable "forseti_version" {
   description = "The version of Forseti to install"
-  default     = "v2.24.0"
+  default     = "v2.25.0"
 }
 
 variable "forseti_repo_url" {

--- a/modules/on_gke/README.md
+++ b/modules/on_gke/README.md
@@ -83,7 +83,7 @@ This sub-module deploys Forseti on GKE.  In short, this deploys a server contain
 | forseti\_home | Forseti installation directory | string | `"$USER_HOME/forseti-security"` | no |
 | forseti\_repo\_url | Git repo for the Forseti installation | string | `"https://github.com/forseti-security/forseti-security"` | no |
 | forseti\_run\_frequency | Schedule of running the Forseti scans | string | `"null"` | no |
-| forseti\_version | The version of Forseti to install | string | `"v2.24.0"` | no |
+| forseti\_version | The version of Forseti to install | string | `"v2.25.0"` | no |
 | forwarding\_rule\_enabled | Forwarding rule scanner enabled. | bool | `"false"` | no |
 | forwarding\_rule\_violations\_should\_notify | Notify for forwarding rule violations | bool | `"true"` | no |
 | git\_sync\_image | The container image used by the config-validator git-sync side-car | string | `"gcr.io/google-containers/git-sync"` | no |
@@ -117,9 +117,9 @@ This sub-module deploys Forseti on GKE.  In short, this deploys a server contain
 | k8s\_config\_validator\_image\_tag | The tag for the config-validator image. | string | `"572e207"` | no |
 | k8s\_forseti\_namespace | The Kubernetes namespace in which to deploy Forseti. | string | `"forseti"` | no |
 | k8s\_forseti\_orchestrator\_image | The container image for the Forseti orchestrator | string | `"gcr.io/forseti-containers/forseti"` | no |
-| k8s\_forseti\_orchestrator\_image\_tag | The tag for the container image for the Forseti orchestrator | string | `"v2.24.0"` | no |
+| k8s\_forseti\_orchestrator\_image\_tag | The tag for the container image for the Forseti orchestrator | string | `"v2.25.0"` | no |
 | k8s\_forseti\_server\_image | The container image for the Forseti server | string | `"gcr.io/forseti-containers/forseti"` | no |
-| k8s\_forseti\_server\_image\_tag | The tag for the container image for the Forseti server | string | `"v2.24.0"` | no |
+| k8s\_forseti\_server\_image\_tag | The tag for the container image for the Forseti server | string | `"v2.25.0"` | no |
 | k8s\_forseti\_server\_ingress\_cidr | If network_policy is true, k8s_forseti_server_ingress_cidr will restrict connections to the Forseti Server service from the CIDR's specified | string | `""` | no |
 | k8s\_tiller\_sa\_name | The Kubernetes Service Account used by Tiller | string | `"tiller"` | no |
 | ke\_scanner\_enabled | KE scanner enabled. | bool | `"false"` | no |

--- a/modules/on_gke/README.md
+++ b/modules/on_gke/README.md
@@ -98,7 +98,7 @@ This sub-module deploys Forseti on GKE.  In short, this deploys a server contain
 | groups\_settings\_violations\_should\_notify | Notify for groups settings violations | bool | `"true"` | no |
 | groups\_violations\_should\_notify | Notify for Groups violations | bool | `"true"` | no |
 | gsuite\_admin\_email | G-Suite administrator email address to manage your Forseti installation | string | `""` | no |
-| helm\_chart\_version | The version of the Helm chart to use | string | `"2.1.0"` | no |
+| helm\_chart\_version | The version of the Helm chart to use | string | `"2.2.0"` | no |
 | helm\_repository\_url | The Helm repository containing the 'forseti-security' Helm charts | string | `"https://forseti-security-charts.storage.googleapis.com/release/"` | no |
 | iam\_disable\_polling | Whether to disable polling for IAM API | bool | `"false"` | no |
 | iam\_max\_calls | Maximum calls that can be made to IAM API | string | `"90"` | no |

--- a/modules/on_gke/main.tf
+++ b/modules/on_gke/main.tf
@@ -225,10 +225,12 @@ resource "helm_release" "forseti-security" {
   version       = var.helm_chart_version
   chart         = "forseti-security"
   recreate_pods = var.recreate_pods
-  depends_on = ["kubernetes_role_binding.tiller",
-    "kubernetes_namespace.forseti",
+  depends_on = [
+    "google_service_account_iam_binding.forseti_client_workload_identity",
     "google_service_account_iam_binding.forseti_server_workload_identity",
-  "google_service_account_iam_binding.forseti_client_workload_identity"]
+    "kubernetes_namespace.forseti",
+    "kubernetes_role_binding.tiller"
+  ]
 
   set {
     name  = "database.username"

--- a/modules/on_gke/variables.tf
+++ b/modules/on_gke/variables.tf
@@ -60,7 +60,6 @@ variable "sendgrid_api_key" {
 #------------#
 # GKE config #
 #------------#
-
 variable "gke_node_pool_name" {
   description = "The name of the GKE node-pool where Forseti is being deployed"
   default     = "default-pool"
@@ -710,7 +709,6 @@ variable "inventory_email_summary_enabled" {
 #---------------------------------------#
 # Groups Settings scanner configuration #
 #---------------------------------------#
-
 variable "groups_settings_max_calls" {
   description = "Maximum calls that can be made to the G Suite Groups API"
   default     = "5"
@@ -893,7 +891,6 @@ variable "cloudsql_password" {
 #-------------#
 # Helm config #
 #-------------#
-
 variable "git_sync_image" {
   description = "The container image used by the config-validator git-sync side-car"
   default     = "gcr.io/google-containers/git-sync"
@@ -911,7 +908,7 @@ variable "git_sync_wait" {
 
 variable "helm_chart_version" {
   description = "The version of the Helm chart to use"
-  default     = "2.1.0"
+  default     = "2.2.0"
 }
 
 variable "helm_repository_url" {

--- a/modules/on_gke/variables.tf
+++ b/modules/on_gke/variables.tf
@@ -80,7 +80,7 @@ variable "gsuite_admin_email" {
 
 variable "forseti_version" {
   description = "The version of Forseti to install"
-  default     = "v2.24.0"
+  default     = "v2.25.0"
 }
 
 variable "forseti_repo_url" {
@@ -941,7 +941,7 @@ variable "k8s_forseti_orchestrator_image" {
 
 variable "k8s_forseti_orchestrator_image_tag" {
   description = "The tag for the container image for the Forseti orchestrator"
-  default     = "v2.24.0"
+  default     = "v2.25.0"
 }
 
 variable "k8s_forseti_server_image" {
@@ -951,7 +951,7 @@ variable "k8s_forseti_server_image" {
 
 variable "k8s_forseti_server_image_tag" {
   description = "The tag for the container image for the Forseti server"
-  default     = "v2.24.0"
+  default     = "v2.25.0"
 }
 
 variable "k8s_forseti_server_ingress_cidr" {

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -23,7 +23,7 @@ variable "project_id" {
 
 variable "forseti_version" {
   description = "The version of Forseti to install"
-  default     = "v2.24.0"
+  default     = "v2.25.0"
 }
 
 variable "forseti_repo_url" {

--- a/test/fixtures/custom_service_accounts/main.tf
+++ b/test/fixtures/custom_service_accounts/main.tf
@@ -17,11 +17,13 @@
 module "custom-service-accounts" {
   source = "../../.."
 
-  project_id = var.project_id
-  org_id     = var.org_id
-  domain     = var.domain
-  network    = var.network
-  subnetwork = var.subnetwork
+  project_id      = var.project_id
+  org_id          = var.org_id
+  domain          = var.domain
+  network         = var.network
+  subnetwork      = var.subnetwork
+  forseti_version = var.forseti_version
+
   # The resources that create the service accounts are in test/setup/iam.tf.
   # Did not create them here and directly reference them becuase `count` will complain
   # google_service_account.forseti_{server,client}.email are unknown until apply.

--- a/test/fixtures/custom_service_accounts/variables.tf
+++ b/test/fixtures/custom_service_accounts/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+variable "forseti_version" {
+  description = "The version of Forseti to install"
+  default     = "master"
+}
 
 variable "org_id" {
   description = "GCP Organization ID that Forseti will have purview over"

--- a/test/fixtures/install_simple/main.tf
+++ b/test/fixtures/install_simple/main.tf
@@ -70,7 +70,6 @@ module "forseti-install-simple" {
   region             = var.region
   network            = var.network
   subnetwork         = var.subnetwork
-  forseti_version    = var.forseti_version
   network_project    = var.network_project
 
   instance_metadata = {

--- a/test/fixtures/install_simple/main.tf
+++ b/test/fixtures/install_simple/main.tf
@@ -71,6 +71,7 @@ module "forseti-install-simple" {
   network            = var.network
   subnetwork         = var.subnetwork
   network_project    = var.network_project
+  forseti_version    = var.forseti_version
 
   instance_metadata = {
     sshKeys = "ubuntu:${tls_private_key.main.public_key_openssh}"

--- a/test/fixtures/install_simple/variables.tf
+++ b/test/fixtures/install_simple/variables.tf
@@ -22,11 +22,6 @@ variable "gsuite_admin_email" {
   description = "The email of a GSuite super admin, used for pulling user directory information *and* sending notifications."
 }
 
-variable "forseti_version" {
-  description = "The version of Forseti to install"
-  default     = "master"
-}
-
 variable "instance_metadata" {
   description = "Metadata key/value pairs to make available from within the client and server instances."
   type        = map(string)

--- a/test/fixtures/install_simple/variables.tf
+++ b/test/fixtures/install_simple/variables.tf
@@ -18,6 +18,11 @@ variable "domain" {
   description = "The domain associated with the GCP Organization ID"
 }
 
+variable "forseti_version" {
+  description = "The version of Forseti to install"
+  default     = "master"
+}
+
 variable "gsuite_admin_email" {
   description = "The email of a GSuite super admin, used for pulling user directory information *and* sending notifications."
 }

--- a/test/fixtures/manage_rules_disabled/main.tf
+++ b/test/fixtures/manage_rules_disabled/main.tf
@@ -58,7 +58,6 @@ module "forseti-manage-rules-disabled" {
   domain               = var.domain
   network              = var.network
   subnetwork           = var.subnetwork
-  forseti_version      = "master"
   client_enabled       = false
   manage_rules_enabled = false
   server_instance_metadata = {

--- a/test/fixtures/manage_rules_disabled/main.tf
+++ b/test/fixtures/manage_rules_disabled/main.tf
@@ -60,6 +60,8 @@ module "forseti-manage-rules-disabled" {
   subnetwork           = var.subnetwork
   client_enabled       = false
   manage_rules_enabled = false
+  forseti_version      = var.forseti_version
+
   server_instance_metadata = {
     sshKeys = "ubuntu:${tls_private_key.main.public_key_openssh}"
   }

--- a/test/fixtures/manage_rules_disabled/variables.tf
+++ b/test/fixtures/manage_rules_disabled/variables.tf
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+variable "forseti_version" {
+  description = "The version of Forseti to install"
+  default     = "master"
+}
+
 variable "domain" {
   description = "The domain associated with the GCP Organization ID"
 }

--- a/test/fixtures/no_client_vm/main.tf
+++ b/test/fixtures/no_client_vm/main.tf
@@ -17,10 +17,11 @@
 module "no-client-vm" {
   source = "../../.."
 
-  project_id     = var.project_id
-  org_id         = var.org_id
-  domain         = var.domain
-  network        = var.network
-  subnetwork     = var.subnetwork
-  client_enabled = false
+  project_id      = var.project_id
+  org_id          = var.org_id
+  domain          = var.domain
+  network         = var.network
+  subnetwork      = var.subnetwork
+  client_enabled  = false
+  forseti_version = var.forseti_version
 }

--- a/test/fixtures/no_client_vm/variables.tf
+++ b/test/fixtures/no_client_vm/variables.tf
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+variable "forseti_version" {
+  description = "The version of Forseti to install"
+  default     = "master"
+}
+
 variable "org_id" {
   description = "GCP Organization ID that Forseti will have purview over"
 }

--- a/test/fixtures/shared_vpc/main.tf
+++ b/test/fixtures/shared_vpc/main.tf
@@ -54,6 +54,7 @@ module "forseti-shared-vpc" {
   network_project    = var.network_project
   org_id             = var.org_id
   domain             = var.domain
+  forseti_version    = var.forseti_version
 
   instance_metadata = {
     sshKeys = "ubuntu:${tls_private_key.main.public_key_openssh}"

--- a/test/fixtures/shared_vpc/main.tf
+++ b/test/fixtures/shared_vpc/main.tf
@@ -54,7 +54,6 @@ module "forseti-shared-vpc" {
   network_project    = var.network_project
   org_id             = var.org_id
   domain             = var.domain
-  forseti_version    = var.forseti_version
 
   instance_metadata = {
     sshKeys = "ubuntu:${tls_private_key.main.public_key_openssh}"

--- a/test/fixtures/shared_vpc/variables.tf
+++ b/test/fixtures/shared_vpc/variables.tf
@@ -18,11 +18,6 @@ variable "domain" {
   description = "Organization domain"
 }
 
-variable "forseti_version" {
-  description = "The version of Forseti to install"
-  default     = "master"
-}
-
 variable "gsuite_admin_email" {
   description = "G Suite admin email"
 }

--- a/test/fixtures/shared_vpc/variables.tf
+++ b/test/fixtures/shared_vpc/variables.tf
@@ -18,6 +18,11 @@ variable "domain" {
   description = "Organization domain"
 }
 
+variable "forseti_version" {
+  description = "The version of Forseti to install"
+  default     = "master"
+}
+
 variable "gsuite_admin_email" {
   description = "G Suite admin email"
 }

--- a/test/fixtures/shielded_vm/main.tf
+++ b/test/fixtures/shielded_vm/main.tf
@@ -25,6 +25,7 @@ module "shielded-vm" {
   server_private   = true
   client_private   = true
   cloudsql_private = true
+  forseti_version  = var.forseti_version
 
   // using shielded VM image for both client and server VMs
   server_boot_image = "gce-uefi-images/ubuntu-1804-lts"

--- a/test/fixtures/shielded_vm/variables.tf
+++ b/test/fixtures/shielded_vm/variables.tf
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+variable "forseti_version" {
+  description = "The version of Forseti to install"
+  default     = "master"
+}
+
 variable "org_id" {
   description = "GCP Organization ID that Forseti will have purview over"
 }

--- a/test/integration/install_simple/controls/client.rb
+++ b/test/integration/install_simple/controls/client.rb
@@ -15,7 +15,7 @@
 require "yaml"
 
 forseti_server_vm_internal_dns = attribute("forseti-server-vm-internal-dns")
-forseti_version = "2.24.0"
+forseti_version = "2.25.0"
 
 control "client" do
   title "Forseti client instance resources"

--- a/test/integration/install_simple/controls/server.rb
+++ b/test/integration/install_simple/controls/server.rb
@@ -14,7 +14,7 @@
 
 require "yaml"
 
-forseti_version = "2.24.0"
+forseti_version = "2.25.0"
 suffix = attribute("suffix")
 
 control "server" do

--- a/variables.tf
+++ b/variables.tf
@@ -28,7 +28,7 @@ variable "gsuite_admin_email" {
 
 variable "forseti_version" {
   description = "The version of Forseti to install"
-  default     = "v2.24.0"
+  default     = "v2.25.0"
 }
 
 variable "forseti_repo_url" {


### PR DESCRIPTION
Updated changelog, readme, forseti_version, release branch name, helm chart, etc.

In addition added a new cloud build configuration for release to be able to run tests against the release of Forseti being tested, instead of making code changes every time.