### PR TITLE
[PATCH] Patch Release v5.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Extending the adopted spec, each change should have a link to its corresponding pull request appended.
 
-## [v5.2.1] - 2020-03-31
+## [v5.2.1] - 2020-04-01
 
 ### Added
 
-- Support for Forseti v2.25.1 [#561]
+- Support for Forseti v2.25.1 [#563]
 
 ## [v5.2.0] - 2020-03-18
 
@@ -411,7 +411,7 @@ Version 4.0.0 is a backwards-incompatible release. Please see the [upgrade instr
 [v5.2.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v5.1.3...v5.2.0
 [v5.2.1]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v5.2.0...v5.2.1
 
-[#561]: https://github.com/forseti-security/terraform-google-forseti/pull/561
+[#563]: https://github.com/forseti-security/terraform-google-forseti/pull/563
 [#546]: https://github.com/forseti-security/terraform-google-forseti/pull/546
 [#535]: https://github.com/forseti-security/terraform-google-forseti/pull/535
 [#534]: https://github.com/forseti-security/terraform-google-forseti/pull/534

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Extending the adopted spec, each change should have a link to its corresponding pull request appended.
 
+## [v5.2.1] - 2020-03-31
+
+### Added
+
+- Support for Forseti v2.25.1 [#561]
+
 ## [v5.2.0] - 2020-03-18
 
 ### Added
@@ -403,7 +409,9 @@ Version 4.0.0 is a backwards-incompatible release. Please see the [upgrade instr
 [v5.1.2]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v5.1.1...v5.1.2
 [v5.1.3]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v5.1.2...v5.1.3
 [v5.2.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v5.1.3...v5.2.0
+[v5.2.1]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v5.2.0...v5.2.1
 
+[#561]: https://github.com/forseti-security/terraform-google-forseti/pull/561
 [#546]: https://github.com/forseti-security/terraform-google-forseti/pull/546
 [#535]: https://github.com/forseti-security/terraform-google-forseti/pull/535
 [#534]: https://github.com/forseti-security/terraform-google-forseti/pull/534

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Create a file named `main.tf` in an empty directory and copy the contents below 
 ```hcl
     module "forseti" {
       source  = "terraform-google-modules/forseti/google"
-      version = "~> 5.1"
+      version = "~> 5.2.1"
 
       gsuite_admin_email = "superadmin@yourdomain.com"
       domain             = "yourdomain.com"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Google Cloud Shell Walkthrough has been setup to make it easy for users who ar
 
 If you are familiar with Terraform and would like to run Terraform from a different machine, you can skip this walkthrough and move onto the [How to Deploy](#how-to-deploy) section.
 
-[![Open in Google Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fforseti-security%2Fterraform-google-forseti.git&cloudshell_git_branch=modulerelease520&cloudshell_working_dir=examples/install_simple&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&cloudshell_tutorial=.%2Ftutorial.md)
+[![Open in Google Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fforseti-security%2Fterraform-google-forseti.git&cloudshell_git_branch=modulerelease521&cloudshell_working_dir=examples/install_simple&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&cloudshell_tutorial=.%2Ftutorial.md)
 
 ## How to Deploy
 In order to run this module you will need to be authenticated as a user that has access to the project and can create/authorize service accounts at both the organization and project levels. To login to GCP from a shell:
@@ -20,7 +20,7 @@ gcloud auth login
 The repository has several helper scripts that can be used with the deployment process.
 
 ```bash
-git clone --branch modulerelease520 --depth 1 https://github.com/forseti-security/terraform-google-forseti.git
+git clone --branch modulerelease521 --depth 1 https://github.com/forseti-security/terraform-google-forseti.git
 ```
 
 ### Install Terraform
@@ -244,7 +244,7 @@ For this module to work, you need the following APIs enabled on the Forseti proj
 | forseti\_home | Forseti installation directory | string | `"$USER_HOME/forseti-security"` | no |
 | forseti\_repo\_url | Git repo for the Forseti installation | string | `"https://github.com/forseti-security/forseti-security"` | no |
 | forseti\_run\_frequency | Schedule of running the Forseti scans | string | `"null"` | no |
-| forseti\_version | The version of Forseti to install | string | `"v2.25.0"` | no |
+| forseti\_version | The version of Forseti to install | string | `"v2.25.1"` | no |
 | forwarding\_rule\_enabled | Forwarding rule scanner enabled. | bool | `"false"` | no |
 | forwarding\_rule\_violations\_should\_notify | Notify for forwarding rule violations | bool | `"true"` | no |
 | group\_enabled | Group scanner enabled. | bool | `"true"` | no |

--- a/build/int-release.cloudbuild.yaml
+++ b/build/int-release.cloudbuild.yaml
@@ -41,4 +41,4 @@ tags:
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
   _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.4.6'
-  _FORSETI_VERSION: 'v2.25.0'
+  _FORSETI_VERSION: 'v2.25.1'

--- a/examples/install_simple/README.md
+++ b/examples/install_simple/README.md
@@ -2,7 +2,7 @@
 
 This configuration is used to simply install Forseti. It includes a full Cloud Shell [tutorial](./tutorial.md).
 
-[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fforseti-security%2Fterraform-google-forseti.git&cloudshell_git_branch=modulerelease520&cloudshell_working_dir=examples/install_simple&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&cloudshell_tutorial=.%2Ftutorial.md)
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fforseti-security%2Fterraform-google-forseti.git&cloudshell_git_branch=modulerelease521&cloudshell_working_dir=examples/install_simple&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&cloudshell_tutorial=.%2Ftutorial.md)
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
@@ -12,7 +12,7 @@ This configuration is used to simply install Forseti. It includes a full Cloud S
 | domain | The domain associated with the GCP Organization ID | string | n/a | yes |
 | forseti\_email\_recipient | Forseti email recipient. | string | `""` | no |
 | forseti\_email\_sender | Forseti email sender. | string | `""` | no |
-| forseti\_version | The version of Forseti to install | string | `"v2.25.0"` | no |
+| forseti\_version | The version of Forseti to install | string | `"v2.25.1"` | no |
 | gsuite\_admin\_email | The email of a GSuite super admin, used for pulling user directory information *and* sending notifications. | string | n/a | yes |
 | instance\_metadata | Metadata key/value pairs to make available from within the client and server instances. | map(string) | `<map>` | no |
 | instance\_tags | Tags to assign the client and server instances. | list(string) | `<list>` | no |

--- a/examples/install_simple/variables.tf
+++ b/examples/install_simple/variables.tf
@@ -65,7 +65,7 @@ variable "forseti_email_recipient" {
 
 variable "forseti_version" {
   description = "The version of Forseti to install"
-  default     = "v2.25.0"
+  default     = "v2.25.1"
 }
 
 variable "region" {

--- a/examples/migrate_forseti/main.tf
+++ b/examples/migrate_forseti/main.tf
@@ -17,7 +17,7 @@
 
 module "forseti" {
   source  = "terraform-google-modules/forseti/google"
-  version = "~> 5.2.1"
+  version = "~> 5.2.0"
 
   # Replace these argument values with those obtained in the Prerequisites section
   domain               = "DOMAIN"

--- a/examples/migrate_forseti/main.tf
+++ b/examples/migrate_forseti/main.tf
@@ -14,33 +14,10 @@
  * limitations under the License.
  */
 
-terraform {
-  required_version = ">= 0.12.0"
-}
-
-provider "google" {
-  version = "~> 2.11.0"
-}
-
-provider "local" {
-  version = "~> 1.3"
-}
-
-provider "null" {
-  version = "~> 2.0"
-}
-
-provider "template" {
-  version = "~> 2.0"
-}
-
-provider "random" {
-  version = "~> 2.0"
-}
 
 module "forseti" {
   source  = "terraform-google-modules/forseti/google"
-  version = "~> 5.1"
+  version = "~> 5.2.1"
 
   # Replace these argument values with those obtained in the Prerequisites section
   domain               = "DOMAIN"

--- a/examples/migrate_forseti/tutorial.md
+++ b/examples/migrate_forseti/tutorial.md
@@ -160,7 +160,7 @@ to match the region where the CAI GCS bucket is deployed.
 Starting with Forseti Security 2.23, Terraform will manage your server
  configuration file for you.  Configuration options will now be input
  variables that are defined in the Terraform module. Available variables
- and their default values can be found [here](https://github.com/forseti-security/terraform-google-forseti/blob/modulerelease520/variables.tf).
+ and their default values can be found [here](https://github.com/forseti-security/terraform-google-forseti/blob/modulerelease521/variables.tf).
  Default values will be used if values are not explicitly added.
  This will ensure upgrading Forseti will be as easy as possible going forward.
 
@@ -202,10 +202,10 @@ to your <walkthrough-editor-select-regex
   regex="Add any Forseti Server Configuration Variables Here">main.tf</walkthrough-editor-select-regex>.
 
 ## Obtain and Run the Import Script
-This [import script](https://github.com/forseti-security/terraform-google-forseti/blob/modulerelease520/helpers/import.sh) will import the Forseti GCP resources into a local state file.
+This [import script](https://github.com/forseti-security/terraform-google-forseti/blob/modulerelease521/helpers/import.sh) will import the Forseti GCP resources into a local state file.
 
 ```sh
-curl --location --remote-name https://raw.githubusercontent.com/forseti-security/terraform-google-forseti/modulerelease520/helpers/import.sh
+curl --location --remote-name https://raw.githubusercontent.com/forseti-security/terraform-google-forseti/modulerelease521/helpers/import.sh
 chmod +x import.sh
 ./import.sh -h
 ```

--- a/examples/on_gke_end_to_end/README.md
+++ b/examples/on_gke_end_to_end/README.md
@@ -76,8 +76,8 @@ This script will also activate necessary APIs required for Terraform to deploy F
 | gsuite\_admin\_email | G-Suite administrator email address to manage your Forseti installation | string | n/a | yes |
 | helm\_repository\_url | The Helm repository containing the 'forseti-security' Helm charts | string | `"https://forseti-security-charts.storage.googleapis.com/release/"` | no |
 | k8s\_forseti\_namespace | The Kubernetes namespace in which to deploy Forseti. | string | `"forseti"` | no |
-| k8s\_forseti\_orchestrator\_image\_tag | The tag for the container image for the Forseti orchestrator | string | `"v2.25.0"` | no |
-| k8s\_forseti\_server\_image\_tag | The tag for the container image for the Forseti server | string | `"v2.25.0"` | no |
+| k8s\_forseti\_orchestrator\_image\_tag | The tag for the container image for the Forseti orchestrator | string | `"v2.25.1"` | no |
+| k8s\_forseti\_server\_image\_tag | The tag for the container image for the Forseti server | string | `"v2.25.1"` | no |
 | k8s\_tiller\_sa\_name | The Kubernetes Service Account used by Tiller | string | `"tiller"` | no |
 | kubernetes\_version | The Kubernetes version of the masters. If set to 'latest' it will pull latest available version in the selected region. | string | `"1.14.10-gke.17"` | no |
 | network | The name of the VPC being created | string | `"forseti-gke-network"` | no |

--- a/examples/on_gke_end_to_end/variables.tf
+++ b/examples/on_gke_end_to_end/variables.tf
@@ -126,12 +126,12 @@ variable "k8s_tiller_sa_name" {
 
 variable "k8s_forseti_orchestrator_image_tag" {
   description = "The tag for the container image for the Forseti orchestrator"
-  default     = "v2.25.0"
+  default     = "v2.25.1"
 }
 
 variable "k8s_forseti_server_image_tag" {
   description = "The tag for the container image for the Forseti server"
-  default     = "v2.25.0"
+  default     = "v2.25.1"
 }
 
 variable "kubernetes_version" {

--- a/examples/shared_vpc/README.md
+++ b/examples/shared_vpc/README.md
@@ -8,7 +8,7 @@ This example illustrates how to set up a Forseti installation with shared VPC.
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | domain | Organization domain | string | n/a | yes |
-| forseti\_version | The version of Forseti to install | string | `"v2.25.0"` | no |
+| forseti\_version | The version of Forseti to install | string | `"v2.25.1"` | no |
 | gsuite\_admin\_email | G Suite admin email | string | n/a | yes |
 | instance\_metadata | Metadata key/value pairs to make available from within the client and server instances. | map(string) | `<map>` | no |
 | network | Name of the shared VPC | string | n/a | yes |

--- a/examples/shared_vpc/variables.tf
+++ b/examples/shared_vpc/variables.tf
@@ -16,7 +16,7 @@
 
 variable "forseti_version" {
   description = "The version of Forseti to install"
-  default     = "v2.25.0"
+  default     = "v2.25.1"
 }
 
 variable "network_project" {

--- a/modules/client/variables.tf
+++ b/modules/client/variables.tf
@@ -23,7 +23,7 @@ variable "project_id" {
 
 variable "forseti_version" {
   description = "The version of Forseti to install"
-  default     = "v2.25.0"
+  default     = "v2.25.1"
 }
 
 variable "forseti_repo_url" {

--- a/modules/on_gke/README.md
+++ b/modules/on_gke/README.md
@@ -83,7 +83,7 @@ This sub-module deploys Forseti on GKE.  In short, this deploys a server contain
 | forseti\_home | Forseti installation directory | string | `"$USER_HOME/forseti-security"` | no |
 | forseti\_repo\_url | Git repo for the Forseti installation | string | `"https://github.com/forseti-security/forseti-security"` | no |
 | forseti\_run\_frequency | Schedule of running the Forseti scans | string | `"null"` | no |
-| forseti\_version | The version of Forseti to install | string | `"v2.25.0"` | no |
+| forseti\_version | The version of Forseti to install | string | `"v2.25.1"` | no |
 | forwarding\_rule\_enabled | Forwarding rule scanner enabled. | bool | `"false"` | no |
 | forwarding\_rule\_violations\_should\_notify | Notify for forwarding rule violations | bool | `"true"` | no |
 | git\_sync\_image | The container image used by the config-validator git-sync side-car | string | `"gcr.io/google-containers/git-sync"` | no |
@@ -117,9 +117,9 @@ This sub-module deploys Forseti on GKE.  In short, this deploys a server contain
 | k8s\_config\_validator\_image\_tag | The tag for the config-validator image. | string | `"572e207"` | no |
 | k8s\_forseti\_namespace | The Kubernetes namespace in which to deploy Forseti. | string | `"forseti"` | no |
 | k8s\_forseti\_orchestrator\_image | The container image for the Forseti orchestrator | string | `"gcr.io/forseti-containers/forseti"` | no |
-| k8s\_forseti\_orchestrator\_image\_tag | The tag for the container image for the Forseti orchestrator | string | `"v2.25.0"` | no |
+| k8s\_forseti\_orchestrator\_image\_tag | The tag for the container image for the Forseti orchestrator | string | `"v2.25.1"` | no |
 | k8s\_forseti\_server\_image | The container image for the Forseti server | string | `"gcr.io/forseti-containers/forseti"` | no |
-| k8s\_forseti\_server\_image\_tag | The tag for the container image for the Forseti server | string | `"v2.25.0"` | no |
+| k8s\_forseti\_server\_image\_tag | The tag for the container image for the Forseti server | string | `"v2.25.1"` | no |
 | k8s\_forseti\_server\_ingress\_cidr | If network_policy is true, k8s_forseti_server_ingress_cidr will restrict connections to the Forseti Server service from the CIDR's specified | string | `""` | no |
 | k8s\_tiller\_sa\_name | The Kubernetes Service Account used by Tiller | string | `"tiller"` | no |
 | ke\_scanner\_enabled | KE scanner enabled. | bool | `"false"` | no |

--- a/modules/on_gke/variables.tf
+++ b/modules/on_gke/variables.tf
@@ -79,7 +79,7 @@ variable "gsuite_admin_email" {
 
 variable "forseti_version" {
   description = "The version of Forseti to install"
-  default     = "v2.25.0"
+  default     = "v2.25.1"
 }
 
 variable "forseti_repo_url" {
@@ -938,7 +938,7 @@ variable "k8s_forseti_orchestrator_image" {
 
 variable "k8s_forseti_orchestrator_image_tag" {
   description = "The tag for the container image for the Forseti orchestrator"
-  default     = "v2.25.0"
+  default     = "v2.25.1"
 }
 
 variable "k8s_forseti_server_image" {
@@ -948,7 +948,7 @@ variable "k8s_forseti_server_image" {
 
 variable "k8s_forseti_server_image_tag" {
   description = "The tag for the container image for the Forseti server"
-  default     = "v2.25.0"
+  default     = "v2.25.1"
 }
 
 variable "k8s_forseti_server_ingress_cidr" {

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -23,7 +23,7 @@ variable "project_id" {
 
 variable "forseti_version" {
   description = "The version of Forseti to install"
-  default     = "v2.25.0"
+  default     = "v2.25.1"
 }
 
 variable "forseti_repo_url" {

--- a/test/integration/install_simple/controls/client.rb
+++ b/test/integration/install_simple/controls/client.rb
@@ -15,7 +15,7 @@
 require "yaml"
 
 forseti_server_vm_internal_dns = attribute("forseti-server-vm-internal-dns")
-forseti_version = "2.25.0"
+forseti_version = "2.25.1"
 
 control "client" do
   title "Forseti client instance resources"

--- a/test/integration/install_simple/controls/server.rb
+++ b/test/integration/install_simple/controls/server.rb
@@ -14,7 +14,7 @@
 
 require "yaml"
 
-forseti_version = "2.25.0"
+forseti_version = "2.25.1"
 suffix = attribute("suffix")
 
 control "server" do

--- a/variables.tf
+++ b/variables.tf
@@ -28,7 +28,7 @@ variable "gsuite_admin_email" {
 
 variable "forseti_version" {
   description = "The version of Forseti to install"
-  default     = "v2.25.0"
+  default     = "v2.25.1"
 }
 
 variable "forseti_repo_url" {


### PR DESCRIPTION
A new version of Forseti v2.25.1 is being released to fix method calls for organization policies on Forseti Security repo (Issue [#3709](https://github.com/forseti-security/forseti-security/issues/3709). 

This is a patch version of the Forseti TF module to target this release from v5.2.0.

Related to Forseti Security Issue [#3716](https://github.com/forseti-security/forseti-security/issues/3716).