### PR TITLE
Added Service Networking API to the list of APIs to be enabled

### DIFF
--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -57,6 +57,7 @@ module "forseti-host-project" {
     "serviceusage.googleapis.com",
     "cloudresourcemanager.googleapis.com",
     "iam.googleapis.com",
+    "servicenetworking.googleapis.com",
     "storage-api.googleapis.com",
     "storage-component.googleapis.com",
     "pubsub.googleapis.com",


### PR DESCRIPTION
Added [Service Networking API](https://cloud.google.com/service-infrastructure/docs/service-networking/reference/rest) to the list of APIs to be enabled.