### PR TITLE
 Fix failing tests on master

### DIFF
--- a/test/integration/install_simple/controls/network.rb
+++ b/test/integration/install_simple/controls/network.rb
@@ -16,7 +16,7 @@
 project_id = attribute('project_id')
 forseti_server_vm_name = attribute('forseti-server-vm-name')
 forseti_client_vm_name = attribute('forseti-client-vm-name')
-forseti_cloud_nat_name = 'clout-nat-' + project_id
+forseti_cloud_nat_name = 'cloud-nat-' + project_id
 forseti_router_name = 'router-' + project_id
 
 control 'forseti-nat' do

--- a/test/integration/shared/controls/forseti.rb
+++ b/test/integration/shared/controls/forseti.rb
@@ -154,9 +154,9 @@ control 'forseti' do
 
     it "denies TCP, UDP, and ICMP" do
         expect(subject.denied).to contain_exactly(
-          an_object_having_attributes(ip_protocol: 'icmp'),
-          an_object_having_attributes(ip_protocol: 'tcp'),
-          an_object_having_attributes(ip_protocol: 'udp')
+          an_object_having_attributes(ip_protocol: 'icmp', ports: nil),
+          an_object_having_attributes(ip_protocol: 'tcp', ports: nil),
+          an_object_having_attributes(ip_protocol: 'udp', ports: nil)
         )
     end
   end
@@ -168,9 +168,9 @@ control 'forseti' do
 
     it "denies TCP, UDP, and ICMP" do
         expect(subject.denied).to contain_exactly(
-          an_object_having_attributes(ip_protocol: 'icmp'),
-          an_object_having_attributes(ip_protocol: 'tcp'),
-          an_object_having_attributes(ip_protocol: 'udp')
+          an_object_having_attributes(ip_protocol: 'icmp', ports: nil),
+          an_object_having_attributes(ip_protocol: 'tcp', ports: nil),
+          an_object_having_attributes(ip_protocol: 'udp', ports: nil)
         )
     end
   end

--- a/test/integration/shared/controls/forseti.rb
+++ b/test/integration/shared/controls/forseti.rb
@@ -125,57 +125,53 @@ control 'forseti' do
     its('object_names') { should include(*files) }
   end
 
-  describe google_service_account(name: "projects/#{project_id}/serviceAccounts/#{forseti_client_service_account}") do
+  describe google_service_account(project: project_id, name: forseti_client_service_account) do
     its(:email) { should eq forseti_client_service_account }
     its(:display_name) { should eq "Forseti Client Service Account" }
   end
 
-  describe google_service_account(name: "projects/#{project_id}/serviceAccounts/#{forseti_server_service_account}") do
+  describe google_service_account(project: project_id, name: forseti_server_service_account) do
     its(:email) { should eq forseti_server_service_account }
     its(:display_name) { should eq "Forseti Server Service Account" }
   end
 
   describe google_compute_firewall(project: network_project, name: "forseti-server-allow-grpc-#{suffix}") do
-    let(:allowed) { subject.allowed.map(&:item) }
-
     its('source_ranges') { should eq ["10.128.0.0/9"] }
     its('direction') { should eq 'INGRESS' }
     its('priority') { should eq 100 }
 
     it "allows gRPC traffic" do
-      expect(allowed).to contain_exactly({ip_protocol: "tcp", ports: ["50051", "50052"]})
+      expect(subject.allowed).to contain_exactly(
+          an_object_having_attributes(ip_protocol: 'tcp', ports: ['50051', '50052'])
+      )
     end
   end
 
   describe google_compute_firewall(project: network_project, name: "forseti-server-deny-all-#{suffix}") do
-    let(:denied) { subject.denied.map(&:item) }
-
     its('source_ranges') { should eq ["0.0.0.0/0"] }
     its('direction') { should eq 'INGRESS' }
     its('priority') { should eq 200 }
 
     it "denies TCP, UDP, and ICMP" do
-      expect(denied).to contain_exactly(
-        {ip_protocol: "icmp"},
-        {ip_protocol: "tcp"},
-        {ip_protocol: "udp"}
-      )
+        expect(subject.denied).to contain_exactly(
+          an_object_having_attributes(ip_protocol: 'icmp'),
+          an_object_having_attributes(ip_protocol: 'tcp'),
+          an_object_having_attributes(ip_protocol: 'udp')
+        )
     end
   end
 
   describe google_compute_firewall(project: network_project, name: "forseti-client-deny-all-#{suffix}") do
-    let(:denied) { subject.denied.map(&:item) }
-
     its('source_ranges') { should eq ["0.0.0.0/0"] }
     its('direction') { should eq 'INGRESS' }
     its('priority') { should eq 200 }
 
     it "denies TCP, UDP, and ICMP" do
-      expect(denied).to contain_exactly(
-        {ip_protocol: "icmp"},
-        {ip_protocol: "tcp"},
-        {ip_protocol: "udp"}
-      )
+        expect(subject.denied).to contain_exactly(
+          an_object_having_attributes(ip_protocol: 'icmp'),
+          an_object_having_attributes(ip_protocol: 'tcp'),
+          an_object_having_attributes(ip_protocol: 'udp')
+        )
     end
   end
 end


### PR DESCRIPTION
There were some updates for the gcp backend released [8 days ago](https://github.com/inspec/inspec-gcp/releases) which broke some of the controls.

Update service account controls for new gcb backend. Update firewall controls to work without item. Fix nat controls, not sure how these were ever working :)

Resolves #570 