### PR TITLE
Lock real-time-enforcer to specific release tag

### DIFF
--- a/modules/real_time_enforcer/templates/cloud-init.yml
+++ b/modules/real_time_enforcer/templates/cloud-init.yml
@@ -71,7 +71,7 @@ write_files:
                                   -e OPA_URL="http://opa-server:8181/v1/data" \
                                   -e ENFORCE=true \
                                   -e STACKDRIVER_LOGGING=true \
-                                  forsetisecurity/real-time-enforcer
+                                  forsetisecurity/real-time-enforcer:v0.1.27
 
     ExecStopPost=-/usr/bin/docker stop enforcer
     ExecStopPost=-/usr/bin/docker rm enforcer


### PR DESCRIPTION
Lock real-time-enforcer to the final release of v0.x