### PR TITLE
Update google-beta namespace

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -22,7 +22,7 @@ terraform {
       version = "~> 3.7"
     }
     google-beta = {
-      source  = "terraform-providers/google-beta"
+      source  = "hashicorp/google-beta"
       version = "~> 3.7"
     }
     helm = {


### PR DESCRIPTION
The Google Beta provider has been moved a different namespace as per https://github.com/hashicorp/terraform/issues/25622.

This PR fixes that change.