### PR TITLE
Output the zone and self_link for created GCE instances

### DIFF
--- a/modules/client/outputs.tf
+++ b/modules/client/outputs.tf
@@ -23,3 +23,13 @@ output "forseti-client-vm-ip" {
   description = "Forseti Client VM private IP address"
   value       = var.client_enabled ? google_compute_instance.forseti-client[0].network_interface[0].network_ip : null
 }
+
+output "forseti-client-vm-zone" {
+  description = "Forseti Client VM zone"
+  value       = var.client_enabled ? google_compute_instance.forseti-client[0].zone : null
+}
+
+output "forseti-client-vm-self_link" {
+  description = "Forseti Client VM self_link"
+  value       = var.client_enabled ? google_compute_instance.forseti-client[0].self_link : null
+}

--- a/modules/cloudsql/outputs.tf
+++ b/modules/cloudsql/outputs.tf
@@ -54,3 +54,14 @@ output "forseti-cloudsql-password" {
   value       = local.cloudsql_password
   sensitive   = true
 }
+
+output "forseti-cloudsql-zone" {
+  description = "CloudSQL instance zone"
+  value       = local.cloudsql_zone
+  sensitive   = true
+}
+
+output "forseti-cloudsql-self_link" {
+  description = "Forseti master CloudSQL instance self_link"
+  value       = google_sql_database_instance.master.self_link
+}

--- a/modules/server/outputs.tf
+++ b/modules/server/outputs.tf
@@ -38,3 +38,13 @@ output "google-cloud-sdk-version" {
   description = "Version of the Google Cloud SDK installed"
   value       = var.google_cloud_sdk_version
 }
+
+output "forseti-server-vm-zone" {
+  description = "Forseti server VM zone"
+  value       = google_compute_instance.forseti-server.zone
+}
+
+output "forseti-server-vm-self_link" {
+  description = "Forseti server VM self_link"
+  value       = google_compute_instance.forseti-server.self_link
+}


### PR DESCRIPTION
Outputs I asked for in https://github.com/forseti-security/terraform-google-forseti/issues/613

`make generate_docs` has been executed, but it didn't update anything.
I'll gladly add the outputs to READMEs manually if necessary.