### PR TITLE
Ignore content_language changes on rules

### DIFF
--- a/modules/rules/main.tf
+++ b/modules/rules/main.tf
@@ -66,6 +66,7 @@ resource "google_storage_bucket_object" "main" {
   lifecycle {
     ignore_changes = [
       content,
+      content_language,
       detect_md5hash,
     ]
   }


### PR DESCRIPTION
```
  # module.sct_forseti_dev.module.server_rules.google_storage_bucket_object.main[23] must be replaced
-/+ resource "google_storage_bucket_object" "main" {
        bucket           = "forseti-server-........"
        content          = (sensitive value)
      - content_language = "en" -> null # forces replacement
```

Ignoring content and md5 hash changes tells me you really want to allow the end user to change rules without the module overwriting them.
So ignore content_language too.

We're using CFT to manage this deployment if that makes any difference.