### PR TITLE
Allow Cloud SQL deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ For this module to work, you need the following APIs enabled on the Forseti proj
 | cloudsql\_db\_password | CloudSQL database password | string | `""` | no |
 | cloudsql\_db\_port | CloudSQL database port | string | `"3306"` | no |
 | cloudsql\_db\_user | CloudSQL database user | string | `"forseti_security_user"` | no |
+| cloudsql\_deletion\_protection | CloudSQL deletion protection | bool | `"true"` | no |
 | cloudsql\_disk\_size | The size of data disk, in GB. Size of a running instance cannot be reduced but can be increased. | string | `"25"` | no |
 | cloudsql\_labels | CloudSQL instance labels | map(string) | `<map>` | no |
 | cloudsql\_net\_write\_timeout | See MySQL documentation: https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_net_write_timeout | string | `"240"` | no |

--- a/main.tf
+++ b/main.tf
@@ -183,24 +183,25 @@ module "server" {
 }
 
 module "cloudsql" {
-  source                     = "./modules/cloudsql"
-  cloudsql_db_name           = var.cloudsql_db_name
-  cloudsql_disk_size         = var.cloudsql_disk_size
-  cloudsql_net_write_timeout = var.cloudsql_net_write_timeout
-  cloudsql_password          = var.cloudsql_db_password
-  cloudsql_private           = var.cloudsql_private
-  cloudsql_region            = var.cloudsql_region
-  cloudsql_availability_type = var.cloudsql_availability_type
-  cloudsql_type              = var.cloudsql_type
-  cloudsql_user              = var.cloudsql_db_user
-  cloudsql_user_host         = var.cloudsql_user_host
-  cloudsql_labels            = var.cloudsql_labels
-  enable_service_networking  = var.enable_service_networking
-  network                    = var.network
-  network_project            = var.network_project
-  project_id                 = var.project_id
-  services                   = google_project_service.main.*.service
-  suffix                     = local.random_hash
+  source                       = "./modules/cloudsql"
+  cloudsql_db_name             = var.cloudsql_db_name
+  cloudsql_disk_size           = var.cloudsql_disk_size
+  cloudsql_net_write_timeout   = var.cloudsql_net_write_timeout
+  cloudsql_password            = var.cloudsql_db_password
+  cloudsql_private             = var.cloudsql_private
+  cloudsql_region              = var.cloudsql_region
+  cloudsql_availability_type   = var.cloudsql_availability_type
+  cloudsql_type                = var.cloudsql_type
+  cloudsql_user                = var.cloudsql_db_user
+  cloudsql_user_host           = var.cloudsql_user_host
+  cloudsql_labels              = var.cloudsql_labels
+  cloudsql_deletion_protection = var.cloudsql_deletion_protection
+  enable_service_networking    = var.enable_service_networking
+  network                      = var.network
+  network_project              = var.network_project
+  project_id                   = var.project_id
+  services                     = google_project_service.main.*.service
+  suffix                       = local.random_hash
 }
 
 module "server_iam" {

--- a/modules/cloudsql/main.tf
+++ b/modules/cloudsql/main.tf
@@ -73,10 +73,11 @@ resource "google_service_networking_connection" "private_vpc_connection" {
 # Forseti SQL database #
 #----------------------#
 resource "google_sql_database_instance" "master" {
-  name             = local.cloudsql_name
-  project          = var.project_id
-  region           = var.cloudsql_region
-  database_version = "MYSQL_5_7"
+  name                = local.cloudsql_name
+  project             = var.project_id
+  region              = var.cloudsql_region
+  database_version    = "MYSQL_5_7"
+  deletion_protection = var.cloudsql_deletion_protection
 
   settings {
     tier              = var.cloudsql_type

--- a/modules/cloudsql/variables.tf
+++ b/modules/cloudsql/variables.tf
@@ -105,3 +105,8 @@ variable "cloudsql_labels" {
   type        = map(string)
   default     = {}
 }
+
+variable "cloudsql_deletion_protection" {
+  description = "CloudSQL deletion protection"
+  default     = true
+}

--- a/modules/on_gke/README.md
+++ b/modules/on_gke/README.md
@@ -45,6 +45,7 @@ This sub-module deploys Forseti on GKE.  In short, this deploys a server contain
 | cloudsql\_acl\_enabled | Cloud SQL scanner enabled. | bool | `"true"` | no |
 | cloudsql\_acl\_violations\_should\_notify | Notify for CloudSQL ACL violations | bool | `"true"` | no |
 | cloudsql\_db\_name | CloudSQL database name | string | `"forseti_security"` | no |
+| cloudsql\_deletion\_protection | CloudSQL deletion protection | bool | `"true"` | no |
 | cloudsql\_disk\_size | The size of data disk, in GB. Size of a running instance cannot be reduced but can be increased. | string | `"25"` | no |
 | cloudsql\_net\_write\_timeout | See MySQL documentation: https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_net_write_timeout | string | `"240"` | no |
 | cloudsql\_password | CloudSQL password | string | `""` | no |

--- a/modules/on_gke/main.tf
+++ b/modules/on_gke/main.tf
@@ -476,20 +476,21 @@ module "client" {
 # Forseti CloudSQL #
 #------------------#
 module "cloudsql" {
-  source                     = "../cloudsql"
-  cloudsql_disk_size         = var.cloudsql_disk_size
-  cloudsql_private           = var.cloudsql_private
-  cloudsql_region            = var.cloudsql_region
-  cloudsql_type              = var.cloudsql_type
-  cloudsql_db_name           = var.cloudsql_db_name
-  cloudsql_user_host         = var.cloudsql_user_host
-  cloudsql_net_write_timeout = var.cloudsql_net_write_timeout
-  enable_service_networking  = var.enable_service_networking
-  network                    = var.network
-  network_project            = var.network_project
-  project_id                 = var.project_id
-  services                   = google_project_service.main.*.service
-  suffix                     = local.random_hash
+  source                       = "../cloudsql"
+  cloudsql_disk_size           = var.cloudsql_disk_size
+  cloudsql_private             = var.cloudsql_private
+  cloudsql_region              = var.cloudsql_region
+  cloudsql_type                = var.cloudsql_type
+  cloudsql_db_name             = var.cloudsql_db_name
+  cloudsql_user_host           = var.cloudsql_user_host
+  cloudsql_net_write_timeout   = var.cloudsql_net_write_timeout
+  cloudsql_deletion_protection = var.cloudsql_deletion_protection
+  enable_service_networking    = var.enable_service_networking
+  network                      = var.network
+  network_project              = var.network_project
+  project_id                   = var.project_id
+  services                     = google_project_service.main.*.service
+  suffix                       = local.random_hash
 }
 
 #--------------------#

--- a/modules/on_gke/variables.tf
+++ b/modules/on_gke/variables.tf
@@ -910,6 +910,12 @@ variable "cloudsql_password" {
   default     = ""
 }
 
+variable "cloudsql_deletion_protection" {
+  description = "CloudSQL deletion protection"
+  default     = true
+  type        = bool
+}
+
 #-------------#
 # Helm config #
 #-------------#

--- a/variables.tf
+++ b/variables.tf
@@ -983,6 +983,12 @@ variable "cloudsql_labels" {
   default     = {}
 }
 
+variable "cloudsql_deletion_protection" {
+  description = "CloudSQL deletion protection"
+  default     = true
+  type        = bool
+}
+
 #----------------#
 # Forseti bucket #
 #----------------#


### PR DESCRIPTION
## What Pull Reqeust
parameterized Cloud SQL's `deletion_protection`.

## Why
Cloud SQL( `google_sql_database_instance` ) is default  `deletion_protection = "true"`,  which makes it impossible to destroy terraform. I actually encountered the following situations.

1. terraform apply fails when Cloud SQL's destructive parameters are set.
2. In the situation like forseti setting did not works well(Cloud SQL starts, but GKE does not start well), I want to delete Cloud SQL, but  cannot delete it.
3. even if we want to run forseti as a trial, but after trying, we cannot delete Cloud SQL.

