### PR TITLE
delete google-cloud-sdk install from the startup-script

### DIFF
--- a/modules/client/templates/scripts/forseti-client/forseti_client_startup_script.sh.tpl
+++ b/modules/client/templates/scripts/forseti-client/forseti_client_startup_script.sh.tpl
@@ -9,7 +9,7 @@ USER_HOME=/home/ubuntu
 sudo apt-get update -y
 sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
 sudo apt-get update -y
-sudo apt-get --assume-yes install google-cloud-sdk git unzip
+sudo apt-get --assume-yes install git unzip
 
 # Install fluentd if necessary.
 if [ -e "/usr/sbin/google-fluentd" ]; then

--- a/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
+++ b/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
@@ -20,7 +20,7 @@ echo "Forseti Startup - Updating Ubuntu."
 sudo apt-get update -y
 sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
 sudo apt-get update -y
-sudo apt-get --assume-yes install google-cloud-sdk git unzip
+sudo apt-get --assume-yes install git unzip
 
 if ! [ -e "/usr/sbin/google-fluentd" ]; then
   echo "Forseti Startup - Installing GCP Logging agent."


### PR DESCRIPTION
## Summery
Currently, when creating the forseti in GCE with Terraform, the forseti startup-script does not work.
In the forseti slack community, forseti newers regularly mention that  "I can't install forseti" , and each time I've guided them to #618.

Applying this Pull Request, forseti startup-script will work.
many people are having trouble, could you please merge it?

## Error
`yum install google-cloud-sdk` in the forseti startup-script fails

```
06:11:55 forseti-server-vm-dev startup-script: INFO startup-script: No apt package "google-cloud-sdk", but there is a snap with that name.
06:11:55 forseti-server-vm-dev startup-script: INFO startup-script: Try "snap install google-cloud-sdk"
06:11:55 forseti-server-vm-dev startup-script: INFO startup-script: E: Unable to locate package google-cloud-sdk
06:11:55 forseti-server-vm-dev startup-script: INFO startup-script: Return code 100.
06:11:55 forseti-server-vm-dev startup-script: INFO Finished running startup scripts.
```

## Cause
I guess this is because google-cloud-sdk has been [deleted from the ubuntu package](https://www.ubuntuupdates.org/package/canonical_partner/bionic/partner/base/google-cloud-sdk).
but google-cloud-sdk is already installed on GCE instances by default, so we can simply remove google-cloud-sdk. 


#618 was auto-closed, but I think this fix is necessary, so I re-created a Pull Request.
