### PR TITLE
Update minimum version of the Google provider to 3.52

### DIFF
--- a/examples/external_ip/main.tf
+++ b/examples/external_ip/main.tf
@@ -16,7 +16,7 @@
 
 provider "google" {
   credentials = file(var.credentials_path)
-  version     = "~> 3.7"
+  version     = "~> 3.52"
 }
 
 provider "null" {

--- a/examples/install_simple/main.tf
+++ b/examples/install_simple/main.tf
@@ -21,6 +21,7 @@ data "google_compute_network" "forseti_network" {
 
 module "cloud-nat" {
   source                             = "terraform-google-modules/cloud-nat/google"
+  version                            = "~> 1.4.0"
   name                               = "cloud-nat-${var.project_id}"
   create_router                      = true
   network                            = var.network

--- a/examples/install_simple/versions.tf
+++ b/examples/install_simple/versions.tf
@@ -17,8 +17,8 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    google      = "~> 3.7.0"
-    google-beta = "~> 3.7.0"
+    google      = "~> 3.52.0"
+    google-beta = "~> 3.52.0"
     http        = "~> 1.2.0"
     local       = "~> 1.4.0"
     null        = "~> 2.1.0"

--- a/examples/on_gke/versions.tf
+++ b/examples/on_gke/versions.tf
@@ -18,8 +18,8 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    google      = "~> 3.7.0"
-    google-beta = "~> 3.7.0"
+    google      = "~> 3.52.0"
+    google-beta = "~> 3.52.0"
     helm        = "~> 0.10.4"
     http        = "~> 1.1.0"
     kubernetes  = "~> 1.10.0"

--- a/examples/on_gke_end_to_end/versions.tf
+++ b/examples/on_gke_end_to_end/versions.tf
@@ -17,8 +17,8 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    google      = "~> 3.7.0"
-    google-beta = "~> 3.7.0"
+    google      = "~> 3.52.0"
+    google-beta = "~> 3.52.0"
     helm        = "~> 0.10.4"
     http        = "~> 1.1.0"
     kubernetes  = "~> 1.10.0"

--- a/examples/private_connection/main.tf
+++ b/examples/private_connection/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 3.7.0"
+  version = "~> 3.52.0"
   project = var.project_id
 }
 

--- a/examples/real_time_enforcer/main.tf
+++ b/examples/real_time_enforcer/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 3.7"
+  version = "~> 3.52"
 }
 
 provider "null" {

--- a/examples/shared_vpc/main.tf
+++ b/examples/shared_vpc/main.tf
@@ -15,11 +15,11 @@
  */
 
 provider "google" {
-  version = "~> 3.7"
+  version = "~> 3.52"
 }
 
 provider "google-beta" {
-  version = "~> 3.7"
+  version = "~> 3.52"
 }
 
 provider "local" {

--- a/modules/client/versions.tf
+++ b/modules/client/versions.tf
@@ -18,6 +18,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    google = "~> 3.7"
+    google = "~> 3.52"
   }
 }

--- a/modules/on_gke/versions.tf
+++ b/modules/on_gke/versions.tf
@@ -18,8 +18,8 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    google      = "~> 3.7"
-    google-beta = "~> 3.7"
+    google      = "~> 3.52"
+    google-beta = "~> 3.52"
     helm        = "~> 0.10"
     kubernetes  = "~> 1.10"
     null        = "~> 2.1"

--- a/modules/real_time_enforcer/versions.tf
+++ b/modules/real_time_enforcer/versions.tf
@@ -18,6 +18,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    google = "~> 3.7"
+    google = "~> 3.52"
   }
 }

--- a/modules/server/versions.tf
+++ b/modules/server/versions.tf
@@ -18,6 +18,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    google = "~> 3.7"
+    google = "~> 3.52"
   }
 }

--- a/test/fixtures/real_time_enforcer/modules/enforcer_target/main.tf
+++ b/test/fixtures/real_time_enforcer/modules/enforcer_target/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 3.7"
+  version = "~> 3.52"
 }
 
 resource "random_string" "main" {

--- a/test/fixtures/real_time_enforcer_roles/main.tf
+++ b/test/fixtures/real_time_enforcer_roles/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 3.7"
+  version = "~> 3.52"
 }
 
 resource "random_string" "main" {

--- a/variables.tf
+++ b/variables.tf
@@ -1046,6 +1046,7 @@ variable "firewall_logging" {
   type        = bool
   default     = false
 }
+
 #-------#
 # Flags #
 #-------#

--- a/versions.tf
+++ b/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.7"
+      version = "~> 3.52"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.7"
+      version = "~> 3.52"
     }
     helm = {
       source  = "hashicorp/helm"


### PR DESCRIPTION
This is needed to support the deletion_protection argument for CloudSQL and using the last version of the Cloud NAT module which works with Terraform 0.12. The lint tests will pass, and int test will still fail on not being able to delete the test VMs. The next PR will actually get the tests all passing 👍 