### PR TITLE
Add deletion_protection for Cloud SQL instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ For this module to work, you need the following APIs enabled on the Forseti proj
 | crm\_period | The period of max calls for the CRM  API (in seconds) | string | `"1.2"` | no |
 | cscc\_source\_id | Source ID for CSCC Beta API | string | `""` | no |
 | cscc\_violations\_enabled | Notify for CSCC violations | bool | `"false"` | no |
+| deletion\_protection | Whether or not to allow Terraform to destroy the instance. Unless this field is set to false in Terraform state, a terraform destroy or terraform apply command that deletes the instance will fail. | string | `"true"` | no |
 | domain | The domain associated with the GCP Organization ID | string | n/a | yes |
 | enable\_cai\_bucket | Create a GCS bucket for CAI exports | bool | `"true"` | no |
 | enable\_service\_networking | Create a global service networking peering connection at the VPC level | bool | `"true"` | no |

--- a/examples/external_ip/README.md
+++ b/examples/external_ip/README.md
@@ -8,6 +8,7 @@ This example illustrates how to set up a minimal Forseti installation.
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | credentials\_path | Path to service account json | string | n/a | yes |
+| deletion\_protection | Whether or not to allow Terraform to destroy the instance. Unless this field is set to false in Terraform state, a terraform destroy or terraform apply command that deletes the instance will fail. | string | `"true"` | no |
 | domain | The domain associated with the GCP Organization ID | string | n/a | yes |
 | gsuite\_admin\_email | The email of a GSuite super admin, used for pulling user directory information *and* sending notifications. | string | n/a | yes |
 | instance\_metadata | Metadata key/value pairs to make available from within the client and server instances. | map(string) | `<map>` | no |

--- a/examples/external_ip/main.tf
+++ b/examples/external_ip/main.tf
@@ -57,6 +57,7 @@ module "forseti-install-simple" {
   server_tags              = var.instance_tags
   client_private           = false # enable client public IP
   server_private           = false # enable server public IP
+  deletion_protection      = var.deletion_protection
 
   # These optional blocks allow to override the default `access_config` block
   # (empty by default) for the client and server VMs.

--- a/examples/external_ip/variables.tf
+++ b/examples/external_ip/variables.tf
@@ -56,3 +56,7 @@ variable "public_ptr_domain_name" {
   default     = ""
 }
 
+variable "deletion_protection" {
+  description = "Whether or not to allow Terraform to destroy the instance. Unless this field is set to false in Terraform state, a terraform destroy or terraform apply command that deletes the instance will fail."
+  default     = true
+}

--- a/examples/install_simple/README.md
+++ b/examples/install_simple/README.md
@@ -10,6 +10,7 @@ This configuration is used to simply install Forseti. It includes a full Cloud S
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | config\_validator\_enabled | Config Validator scanner enabled. | bool | `"false"` | no |
+| deletion\_protection | Whether or not to allow Terraform to destroy the instance. Unless this field is set to false in Terraform state, a terraform destroy or terraform apply command that deletes the instance will fail. | string | `"true"` | no |
 | domain | The domain associated with the GCP Organization ID | string | n/a | yes |
 | forseti\_email\_recipient | Forseti email recipient. | string | `""` | no |
 | forseti\_email\_sender | Forseti email sender. | string | `""` | no |

--- a/examples/install_simple/main.tf
+++ b/examples/install_simple/main.tf
@@ -28,15 +28,7 @@ module "cloud-nat" {
   project_id                         = var.project_id
   region                             = var.region
   router                             = "router-${var.project_id}"
-  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
-
-  subnetworks = [
-    {
-      name                     = var.subnetwork
-      source_ip_ranges_to_nat  = ["ALL_IP_RANGES"]
-      secondary_ip_range_names = []
-    }
-  ]
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
 }
 
 module "forseti-install-simple" {
@@ -56,8 +48,9 @@ module "forseti-install-simple" {
   client_tags              = var.instance_tags
 
   # CloudSQL
-  cloudsql_private = var.private
-  cloudsql_region  = var.region
+  cloudsql_private    = var.private
+  cloudsql_region     = var.region
+  deletion_protection = var.deletion_protection
 
   # Forseti
   forseti_email_recipient = var.forseti_email_recipient

--- a/examples/install_simple/variables.tf
+++ b/examples/install_simple/variables.tf
@@ -85,3 +85,8 @@ variable "sendgrid_api_key" {
 variable "subnetwork" {
   description = "The VPC subnetwork where the Forseti client and server will be created"
 }
+
+variable "deletion_protection" {
+  description = "Whether or not to allow Terraform to destroy the instance. Unless this field is set to false in Terraform state, a terraform destroy or terraform apply command that deletes the instance will fail."
+  default     = true
+}

--- a/examples/on_gke/README.md
+++ b/examples/on_gke/README.md
@@ -57,6 +57,7 @@ In order to operate with the Service Account you must activate the following API
 | config\_validator\_enabled | Config Validator scanner enabled. | bool | `"false"` | no |
 | cscc\_source\_id | Source ID for CSCC Beta API | string | `""` | no |
 | cscc\_violations\_enabled | Notify for CSCC violations | bool | `"false"` | no |
+| deletion\_protection | Whether or not to allow Terraform to destroy the instance. Unless this field is set to false in Terraform state, a terraform destroy or terraform apply command that deletes the instance will fail. | string | `"true"` | no |
 | domain | The domain associated with the GCP Organization ID | string | n/a | yes |
 | forseti\_email\_recipient | Email address that receives Forseti notifications | string | `""` | no |
 | forseti\_email\_sender | Email address that sends the Forseti notifications | string | `""` | no |

--- a/examples/on_gke/main.tf
+++ b/examples/on_gke/main.tf
@@ -120,4 +120,5 @@ module "forseti" {
   policy_library_repository_branch = var.policy_library_repository_branch
   policy_library_sync_enabled      = var.policy_library_sync_enabled
   server_log_level                 = var.server_log_level
+  deletion_protection              = var.deletion_protection
 }

--- a/examples/on_gke/variables.tf
+++ b/examples/on_gke/variables.tf
@@ -136,3 +136,8 @@ variable "region" {
   description = "Region where forseti subnetwork will be deployed"
   default     = "us-central1"
 }
+
+variable "deletion_protection" {
+  description = "Whether or not to allow Terraform to destroy the instance. Unless this field is set to false in Terraform state, a terraform destroy or terraform apply command that deletes the instance will fail."
+  default     = true
+}

--- a/examples/on_gke_end_to_end/README.md
+++ b/examples/on_gke_end_to_end/README.md
@@ -62,6 +62,7 @@ This script will also activate necessary APIs required for Terraform to deploy F
 | default\_node\_pool\_disk\_size | Default Node Pool disk size | string | `"100"` | no |
 | default\_node\_pool\_disk\_type | Default Node Pool disk type | string | `"pd-ssd"` | no |
 | default\_node\_pool\_machine\_type | Default Node Pool machine type | string | `"n1-standard-8"` | no |
+| deletion\_protection | Whether or not to allow Terraform to destroy the instance. Unless this field is set to false in Terraform state, a terraform destroy or terraform apply command that deletes the instance will fail. | string | `"true"` | no |
 | domain | The domain associated with the GCP Organization ID | string | n/a | yes |
 | forseti\_email\_recipient | Email address that receives Forseti notifications | string | `""` | no |
 | forseti\_email\_sender | Email address that sends the Forseti notifications | string | `""` | no |

--- a/examples/on_gke_end_to_end/main.tf
+++ b/examples/on_gke_end_to_end/main.tf
@@ -173,4 +173,5 @@ module "forseti" {
   policy_library_repository_branch   = var.policy_library_repository_branch
   policy_library_sync_enabled        = var.policy_library_sync_enabled
   server_log_level                   = var.server_log_level
+  deletion_protection                = var.deletion_protection
 }

--- a/examples/on_gke_end_to_end/variables.tf
+++ b/examples/on_gke_end_to_end/variables.tf
@@ -208,3 +208,8 @@ variable "bucket_cai_location" {
   description = "GCS CAI storage bucket location"
   default     = "us-central1"
 }
+
+variable "deletion_protection" {
+  description = "Whether or not to allow Terraform to destroy the instance. Unless this field is set to false in Terraform state, a terraform destroy or terraform apply command that deletes the instance will fail."
+  default     = true
+}

--- a/examples/private_connection/README.md
+++ b/examples/private_connection/README.md
@@ -56,6 +56,7 @@ In order to operate the following APIs should be active on the example's project
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | block\_egress | Controls whether the forseti infrastructure components can communicate to internet | bool | `"false"` | no |
+| deletion\_protection | Whether or not to allow Terraform to destroy the instance. Unless this field is set to false in Terraform state, a terraform destroy or terraform apply command that deletes the instance will fail. | string | `"true"` | no |
 | domain | The domain associated with the GCP Organization ID | string | n/a | yes |
 | forseti\_version | The version of Forseti to install | string | `"master"` | no |
 | instance\_metadata | Metadata key/value pairs to make available from within the client and server instances. | map(string) | `<map>` | no |

--- a/examples/private_connection/main.tf
+++ b/examples/private_connection/main.tf
@@ -141,6 +141,7 @@ module "forseti" {
   network                  = google_compute_network.network.name
   subnetwork               = google_compute_subnetwork.subnet.name
   forseti_version          = var.forseti_version
+  deletion_protection      = var.deletion_protection
 }
 
 resource "google_compute_firewall" "forseti-server-allow-sql-connection" {

--- a/examples/private_connection/variables.tf
+++ b/examples/private_connection/variables.tf
@@ -47,3 +47,8 @@ variable "instance_metadata" {
   type        = map(string)
   default     = {}
 }
+
+variable "deletion_protection" {
+  description = "Whether or not to allow Terraform to destroy the instance. Unless this field is set to false in Terraform state, a terraform destroy or terraform apply command that deletes the instance will fail."
+  default     = true
+}

--- a/examples/shared_vpc/README.md
+++ b/examples/shared_vpc/README.md
@@ -7,6 +7,7 @@ This example illustrates how to set up a Forseti installation with shared VPC.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| deletion\_protection | Whether or not to allow Terraform to destroy the instance. Unless this field is set to false in Terraform state, a terraform destroy or terraform apply command that deletes the instance will fail. | string | `"true"` | no |
 | domain | Organization domain | string | n/a | yes |
 | forseti\_version | The version of Forseti to install | string | `"v2.25.1"` | no |
 | gsuite\_admin\_email | G Suite admin email | string | n/a | yes |

--- a/examples/shared_vpc/main.tf
+++ b/examples/shared_vpc/main.tf
@@ -54,4 +54,5 @@ module "forseti" {
   client_private           = "true"
   server_private           = "true"
   forseti_version          = var.forseti_version
+  deletion_protection      = var.deletion_protection
 }

--- a/examples/shared_vpc/variables.tf
+++ b/examples/shared_vpc/variables.tf
@@ -57,3 +57,8 @@ variable "instance_metadata" {
   type        = map(string)
   default     = {}
 }
+
+variable "deletion_protection" {
+  description = "Whether or not to allow Terraform to destroy the instance. Unless this field is set to false in Terraform state, a terraform destroy or terraform apply command that deletes the instance will fail."
+  default     = true
+}

--- a/main.tf
+++ b/main.tf
@@ -195,6 +195,7 @@ module "cloudsql" {
   cloudsql_user              = var.cloudsql_db_user
   cloudsql_user_host         = var.cloudsql_user_host
   cloudsql_labels            = var.cloudsql_labels
+  deletion_protection        = var.deletion_protection
   enable_service_networking  = var.enable_service_networking
   network                    = var.network
   network_project            = var.network_project

--- a/modules/cloudsql/main.tf
+++ b/modules/cloudsql/main.tf
@@ -73,10 +73,11 @@ resource "google_service_networking_connection" "private_vpc_connection" {
 # Forseti SQL database #
 #----------------------#
 resource "google_sql_database_instance" "master" {
-  name             = local.cloudsql_name
-  project          = var.project_id
-  region           = var.cloudsql_region
-  database_version = "MYSQL_5_7"
+  name                = local.cloudsql_name
+  project             = var.project_id
+  region              = var.cloudsql_region
+  database_version    = "MYSQL_5_7"
+  deletion_protection = var.deletion_protection
 
   settings {
     tier              = var.cloudsql_type

--- a/modules/cloudsql/variables.tf
+++ b/modules/cloudsql/variables.tf
@@ -105,3 +105,8 @@ variable "cloudsql_labels" {
   type        = map(string)
   default     = {}
 }
+
+variable "deletion_protection" {
+  description = "Whether or not to allow Terraform to destroy the instance. Unless this field is set to false in Terraform state, a terraform destroy or terraform apply command that deletes the instance will fail."
+  default     = true
+}

--- a/modules/on_gke/README.md
+++ b/modules/on_gke/README.md
@@ -67,6 +67,7 @@ This sub-module deploys Forseti on GKE.  In short, this deploys a server contain
 | crm\_period | The period of max calls for the CRM  API (in seconds) | string | `"1.2"` | no |
 | cscc\_source\_id | Source ID for CSCC Beta API | string | `""` | no |
 | cscc\_violations\_enabled | Notify for CSCC violations | bool | `"false"` | no |
+| deletion\_protection | Whether or not to allow Terraform to destroy the instance. Unless this field is set to false in Terraform state, a terraform destroy or terraform apply command that deletes the instance will fail. | string | `"true"` | no |
 | domain | The domain associated with the GCP Organization ID | string | n/a | yes |
 | enable\_cai\_bucket | Create a GCS bucket for CAI exports | bool | `"true"` | no |
 | enable\_service\_networking | Create a global service networking peering connection at the VPC level | bool | `"true"` | no |

--- a/modules/on_gke/main.tf
+++ b/modules/on_gke/main.tf
@@ -484,6 +484,7 @@ module "cloudsql" {
   cloudsql_db_name           = var.cloudsql_db_name
   cloudsql_user_host         = var.cloudsql_user_host
   cloudsql_net_write_timeout = var.cloudsql_net_write_timeout
+  deletion_protection        = var.deletion_protection
   enable_service_networking  = var.enable_service_networking
   network                    = var.network
   network_project            = var.network_project

--- a/modules/on_gke/variables.tf
+++ b/modules/on_gke/variables.tf
@@ -910,6 +910,11 @@ variable "cloudsql_password" {
   default     = ""
 }
 
+variable "deletion_protection" {
+  description = "Whether or not to allow Terraform to destroy the instance. Unless this field is set to false in Terraform state, a terraform destroy or terraform apply command that deletes the instance will fail."
+  default     = true
+}
+
 #-------------#
 # Helm config #
 #-------------#

--- a/test/fixtures/custom_service_accounts/main.tf
+++ b/test/fixtures/custom_service_accounts/main.tf
@@ -17,12 +17,13 @@
 module "custom-service-accounts" {
   source = "../../.."
 
-  project_id      = var.project_id
-  org_id          = var.org_id
-  domain          = var.domain
-  network         = var.network
-  subnetwork      = var.subnetwork
-  forseti_version = var.forseti_version
+  project_id          = var.project_id
+  org_id              = var.org_id
+  domain              = var.domain
+  network             = var.network
+  subnetwork          = var.subnetwork
+  forseti_version     = var.forseti_version
+  deletion_protection = false
 
   # The resources that create the service accounts are in test/setup/iam.tf.
   # Did not create them here and directly reference them becuase `count` will complain

--- a/test/fixtures/install_simple/main.tf
+++ b/test/fixtures/install_simple/main.tf
@@ -86,14 +86,15 @@ module "bastion" {
 module "forseti-install-simple" {
   source = "../../../examples/install_simple"
 
-  gsuite_admin_email = var.gsuite_admin_email
-  project_id         = var.project_id
-  org_id             = var.org_id
-  domain             = var.domain
-  region             = var.region
-  network            = module.forseti-service-network-install-simple.network_name
-  subnetwork         = module.forseti-service-network-install-simple.subnets_names[0]
-  forseti_version    = var.forseti_version
+  gsuite_admin_email  = var.gsuite_admin_email
+  project_id          = var.project_id
+  org_id              = var.org_id
+  domain              = var.domain
+  region              = var.region
+  network             = var.network
+  subnetwork          = var.subnetwork
+  forseti_version     = var.forseti_version
+  deletion_protection = false
 
   config_validator_enabled = var.config_validator_enabled
 

--- a/test/fixtures/manage_rules_disabled/main.tf
+++ b/test/fixtures/manage_rules_disabled/main.tf
@@ -61,6 +61,7 @@ module "forseti-manage-rules-disabled" {
   client_enabled       = false
   manage_rules_enabled = false
   forseti_version      = var.forseti_version
+  deletion_protection  = false
 
   server_instance_metadata = {
     sshKeys = "ubuntu:${tls_private_key.main.public_key_openssh}"

--- a/test/fixtures/no_client_vm/main.tf
+++ b/test/fixtures/no_client_vm/main.tf
@@ -17,11 +17,12 @@
 module "no-client-vm" {
   source = "../../.."
 
-  project_id      = var.project_id
-  org_id          = var.org_id
-  domain          = var.domain
-  network         = var.network
-  subnetwork      = var.subnetwork
-  client_enabled  = false
-  forseti_version = var.forseti_version
+  project_id          = var.project_id
+  org_id              = var.org_id
+  domain              = var.domain
+  network             = var.network
+  subnetwork          = var.subnetwork
+  client_enabled      = false
+  forseti_version     = var.forseti_version
+  deletion_protection = false
 }

--- a/test/fixtures/private_connection/main.tf
+++ b/test/fixtures/private_connection/main.tf
@@ -45,13 +45,14 @@ module "bastion" {
 }
 
 module "forseti-private-connection" {
-  source          = "../../../examples/private_connection"
-  project_id      = var.project_id
-  region          = var.region
-  org_id          = var.org_id
-  domain          = var.domain
-  block_egress    = var.block_egress
-  forseti_version = var.forseti_version
+  source              = "../../../examples/private_connection"
+  project_id          = var.project_id
+  region              = var.region
+  org_id              = var.org_id
+  domain              = var.domain
+  block_egress        = var.block_egress
+  forseti_version     = var.forseti_version
+  deletion_protection = false
 
   instance_metadata = {
     sshKeys = "ubuntu:${tls_private_key.main.public_key_openssh}"

--- a/test/fixtures/shared_vpc/main.tf
+++ b/test/fixtures/shared_vpc/main.tf
@@ -45,16 +45,17 @@ module "bastion" {
 }
 
 module "forseti-shared-vpc" {
-  source             = "../../../examples/shared_vpc"
-  project_id         = var.project_id
-  region             = var.region
-  gsuite_admin_email = var.gsuite_admin_email
-  network            = var.network
-  subnetwork         = var.subnetwork
-  network_project    = var.network_project
-  org_id             = var.org_id
-  domain             = var.domain
-  forseti_version    = var.forseti_version
+  source              = "../../../examples/shared_vpc"
+  project_id          = var.project_id
+  region              = var.region
+  gsuite_admin_email  = var.gsuite_admin_email
+  network             = var.network
+  subnetwork          = var.subnetwork
+  network_project     = var.network_project
+  org_id              = var.org_id
+  domain              = var.domain
+  forseti_version     = var.forseti_version
+  deletion_protection = false
 
   instance_metadata = {
     sshKeys = "ubuntu:${tls_private_key.main.public_key_openssh}"

--- a/test/fixtures/shielded_vm/main.tf
+++ b/test/fixtures/shielded_vm/main.tf
@@ -17,16 +17,17 @@
 module "shielded-vm" {
   source = "../../.."
 
-  project_id       = var.project_id
-  org_id           = var.org_id
-  domain           = var.domain
-  network          = var.network
-  subnetwork       = var.subnetwork
-  network_project  = var.network_project
-  server_private   = true
-  client_private   = true
-  cloudsql_private = true
-  forseti_version  = var.forseti_version
+  project_id          = var.project_id
+  org_id              = var.org_id
+  domain              = var.domain
+  network             = var.network
+  subnetwork          = var.subnetwork
+  network_project     = var.network_project
+  server_private      = true
+  client_private      = true
+  cloudsql_private    = true
+  forseti_version     = var.forseti_version
+  deletion_protection = false
 
   server_shielded_instance_config = {
     enable_secure_boot          = true

--- a/variables.tf
+++ b/variables.tf
@@ -983,6 +983,11 @@ variable "cloudsql_labels" {
   default     = {}
 }
 
+variable "deletion_protection" {
+  description = "Whether or not to allow Terraform to destroy the instance. Unless this field is set to false in Terraform state, a terraform destroy or terraform apply command that deletes the instance will fail."
+  default     = true
+}
+
 #----------------#
 # Forseti bucket #
 #----------------#


### PR DESCRIPTION
Add support for deletion_protection, so that the CloudSQL database instance can be deleted by tests and for users who are trying to destroy the Forseti deployment.