### PR TITLE
Fix deprecated logging agent install script.

### DIFF
--- a/modules/client/templates/scripts/forseti-client/forseti_client_startup_script.sh.tpl
+++ b/modules/client/templates/scripts/forseti-client/forseti_client_startup_script.sh.tpl
@@ -25,8 +25,8 @@ sudo apt-get update -y && sudo apt-get install -y google-cloud-sdk=${google_clou
 # Install fluentd if necessary.
 if [ -e "/usr/sbin/google-fluentd" ]; then
     cd $USER_HOME
-    curl -sSO https://dl.google.com/cloudagents/install-logging-agent.sh
-    bash install-logging-agent.sh
+    curl -sSO https://dl.google.com/cloudagents/add-logging-agent-repo.sh
+    bash add-logging-agent-repo.sh --also-install
 fi
 
 # Install Forseti Security.

--- a/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
+++ b/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
@@ -62,8 +62,8 @@ sudo apt-get update -y && sudo apt-get install -y google-cloud-sdk=${google_clou
 if ! [ -e "/usr/sbin/google-fluentd" ]; then
   echo "Forseti Startup - Installing GCP Logging agent."
   cd $USER_HOME
-  curl -sSO https://dl.google.com/cloudagents/install-logging-agent.sh
-  bash install-logging-agent.sh
+  curl -sSO https://dl.google.com/cloudagents/add-logging-agent-repo.sh
+  bash add-logging-agent-repo.sh --also-install
 fi
 
 # Check whether Cloud SQL proxy is installed.


### PR DESCRIPTION
See https://cloud.google.com/logging/docs/agent/installation for the latest installation instructions.