### PR TITLE
update random plugin provider to version 3.1 to support M1 Macs

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -47,7 +47,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 2.2"
+      version = "~> 3.1"
     }
     template = {
       source  = "hashicorp/template"


### PR DESCRIPTION
update random plugin provider to version 3.1 to support M1 Macs

v2.2 is not supported on M1 Arch and fails.