### PR TITLE
Fix path to crontab lock file.

### DIFF
--- a/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
+++ b/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
@@ -228,6 +228,6 @@ echo -e "root\n$USER" > /etc/cron.allow
 # queue up the jobs.
 # If the cron job failed the acquire lock on the process, it will log a warning message to syslog.
 chmod +x ${forseti_scripts}/run_forseti.sh
-(echo "${forseti_run_frequency} (/usr/bin/flock -n ${forseti_home}/forseti_cron_runner.lock ${forseti_scripts}/run_forseti.sh || echo '[forseti-security] Warning: New Forseti cron job will not be started, because previous Forseti job is still running.') 2>&1 | logger") | crontab -u $USER -
+(echo "${forseti_run_frequency} (/usr/bin/flock -n ${forseti_scripts}/forseti_cron_runner.lock ${forseti_scripts}/run_forseti.sh || echo '[forseti-security] Warning: New Forseti cron job will not be started, because previous Forseti job is still running.') 2>&1 | logger") | crontab -u $USER -
 echo "Forseti Startup - Added the run_forseti.sh to crontab under user $USER."
 echo "Forseti Startup - Execution of startup script finished."


### PR DESCRIPTION
Change crontab lockfile path. The `forseti_home` directory is owned by root and thus cannot be written to by the `ubuntu` user:

```
  File: forseti-security/
  Size: 4096            Blocks: 8          IO Block: 4096   directory
Device: 801h/2049d      Inode: 523664      Links: 17
Access: (0755/drwxr-xr-x)  Uid: (    0/    root)   Gid: (    0/    root)
```

Use the same path as the `run_forseti.sh` (`forseti_scripts`), as that has 777 permissions.