### PR TITLE
Restart Forseti to release used memory

### DIFF
--- a/modules/server/templates/scripts/forseti-server/run_forseti.sh.tpl
+++ b/modules/server/templates/scripts/forseti-server/run_forseti.sh.tpl
@@ -95,4 +95,4 @@ echo "Cleaning up model tables"
 forseti model delete $MODEL_NAME
 
 # Restart Forseti to release used memory
-systemctl restart forseti
+sudo systemctl restart forseti

--- a/modules/server/templates/scripts/forseti-server/run_forseti.sh.tpl
+++ b/modules/server/templates/scripts/forseti-server/run_forseti.sh.tpl
@@ -94,3 +94,5 @@ echo "Finished running Forseti notifier."
 echo "Cleaning up model tables"
 forseti model delete $MODEL_NAME
 
+# Restart Forseti to release used memory
+systemctl restart forseti


### PR DESCRIPTION
Applying the changes in `forseti-security` repository: https://github.com/forseti-security/forseti-security/pull/3612

This PR releases used up memory by restarting Forseti to prevent potential crash and undesired behavior that is caused by memory not released after a process is completed.

The `run_forseti.sh` is deleted from `forseti-security` in this PR https://github.com/forseti-security/forseti-security/pull/3593, mentioning it is migrated to `terraform-google-forseti`

Related issues:
- https://github.com/forseti-security/forseti-security/issues/3425
- https://github.com/forseti-security/forseti-security/issues/3557
- https://github.com/forseti-security/forseti-security/issues/3576